### PR TITLE
246 - wyświetlanie kierowników rejsu

### DIFF
--- a/frontend/src/modules/cruise-schedule/components/cruise-from/CruiseFormManagerSelection.tsx
+++ b/frontend/src/modules/cruise-schedule/components/cruise-from/CruiseFormManagerSelection.tsx
@@ -24,9 +24,26 @@ export function CruiseFormManagerSelectionSection() {
 }
 
 function CruiseFormManagerSelectionReadonly() {
+  const { form } = useCruiseForm();
+  const usersQuery = useUsersQuery();
+
+  const selectedCruiseManagerId = useStore(form.store, (state) => state.values.managersTeam.mainCruiseManagerId);
+  const selectedDeputyManagerId = useStore(form.store, (state) => state.values.managersTeam.mainDeputyManagerId);
+
+  const selectedUserIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    if (selectedCruiseManagerId) ids.add(selectedCruiseManagerId);
+    if (selectedDeputyManagerId) ids.add(selectedDeputyManagerId);
+    return Array.from(ids);
+  }, [selectedCruiseManagerId, selectedDeputyManagerId]);
+
+  const selectedManagersAsOptions = React.useMemo(() => {
+    return getSelectedUsersForDropdown(usersQuery.data ?? [], selectedUserIds);
+  }, [usersQuery.data, selectedUserIds]);
+
   return (
     <CruiseFormManagerSelectionLayout
-      users={[]}
+      users={selectedManagersAsOptions}
       cruiseManagersNotAssignedToApplication={[]}
       isReadonly={true}
       showWarnings={false}
@@ -201,4 +218,14 @@ function getAllUsersForDropdown(
   const sortedUsers = [...assignedUsers, ...unassignedUsers];
 
   return sortedUsers.map(mapPersonToLabel);
+}
+
+function getSelectedUsersForDropdown(users: User[], selectedIds: string[]): AppDropdownInputOption[] {
+  const formUsers: FormUserDto[] = users.map((user) => ({
+    id: user.id,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    email: user.email,
+  }));
+  return formUsers.filter((user) => selectedIds.includes(user.id)).map(mapPersonToLabel);
 }


### PR DESCRIPTION
Closes #246 
problem opisany w issue
było źle, bo opcje przekazywane do AppDropdownInput w trybie Readonly były po prostu puste. były jedynie dostępne id managerów, ale bez labelów

zmodyfikowałem _**CruiseFormManagerSelectionReadonly()**_ żeby w _**users**_ przekazywało tylko managerów, którzy byli wybrani(jako opcje dropdowna, czyli <value,label,..>) 
**_getSelectedUsersForDropdown()_** zrobione w ten sam sposób co **_getAllUsersForDropdown()_** tylko zwraca tylko te opcje co potrzebujemy
a już sam komponent powinien sobie poradzić i poprawnie wyświetlać te labele managerów