### PR TITLE
252 data dokladna-- błędny podglad przelozonego formularza A

### DIFF
--- a/frontend/src/modules/cruise-applications/hooks/FormAApiHooks.tsx
+++ b/frontend/src/modules/cruise-applications/hooks/FormAApiHooks.tsx
@@ -55,6 +55,7 @@ export function useFormAForSupervisorQuery({ cruiseId, supervisorCode }: Supervi
     select: (res) => {
       const dto = res.data as FormADto;
       dto.note ??= '';
+      dto.periodSelectionType = dto.precisePeriodEnd || dto.precisePeriodStart ? 'precise' : 'period';
       return dto;
     },
   });


### PR DESCRIPTION
Closes #252 
Powinno już działać. Problem był taki, że w tym trybie(readonly + FormAForSupervisorPage) podczas zapisywania danych odebranych z backendu nie zapisywane było pole 'periodSelectionType' i nawet go nie było w form.store.state.values, a w komponencie tej sekcji jest odwołanie do tego pola: _const periodSelectionType = form.state.values.periodSelectionType ?? 'period';_
i z tego powodu zawsze to było = 'period', no i dalej już renderowało pola zgodnie z tym typem.

dodałem tylko że przy odbieraniu danych z backendu w tym hook'u to pole jest wyliczane i zapisywane wraz z wszystkimi innymi polami(jeśli jest zwrócona jakaś data precise to na pewno periodSelectionType='precise', widziałem że w jakimś pliku było to praktycznie tak samo zrobione) 