### PR TITLE
chore: add ef to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,4 +11,6 @@ RUN wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod
     dpkg -i packages-microsoft-prod.deb && \
     rm packages-microsoft-prod.deb && \
     apt-get update && \
-    apt-get install -y dotnet-sdk-10.0
+    apt-get install -y dotnet-sdk-10.0 && \
+    dotnet tool install --tool-path /usr/local/bin dotnet-ef --version 10.0.3
+

--- a/backend/ResearchCruiseApp/Application/ExternalServices/IIdentityService.cs
+++ b/backend/ResearchCruiseApp/Application/ExternalServices/IIdentityService.cs
@@ -40,13 +40,22 @@ public interface IIdentityService
 
     Task<Result> AddRoleToUser(Guid userId, string roleName);
 
-    Task<Result> RemoveRoleFromUser(Guid userId, string roleName);
+    Task<Result> RemoveRoleFromUser(
+        Guid userId,
+        string roleName,
+        CancellationToken cancellationToken = default
+    );
 
     Task<IList<string>> GetUserRolesNames(Guid userId);
 
     Task<IList<string>> GetCurrentUserRoleNames();
 
     Task<List<string?>> GetAllRoleNames(CancellationToken cancellationToken);
-    Task<Result> DeleteUser(Guid userId);
-    Task<Result> UpdateUser(Guid userId, UpdateUserFormDto updateUserFormDto);
+
+    Task<Result> DeleteUser(Guid userId, CancellationToken cancellationToken = default);
+    Task<Result> UpdateUser(
+        Guid userId,
+        UpdateUserFormDto updateUserFormDto,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/backend/ResearchCruiseApp/Application/Models/DTOs/CruiseApplications/GuestTeamDto.cs
+++ b/backend/ResearchCruiseApp/Application/Models/DTOs/CruiseApplications/GuestTeamDto.cs
@@ -2,7 +2,7 @@ namespace ResearchCruiseApp.Application.Models.DTOs.CruiseApplications;
 
 public class GuestTeamDto
 {
-    public string Name { get; init; } = null!;
+    public string? Name { get; init; }
 
     public string NoOfPersons { get; init; } = null!;
 }

--- a/backend/ResearchCruiseApp/Application/Models/DTOs/CruiseApplications/PermissionDto.cs
+++ b/backend/ResearchCruiseApp/Application/Models/DTOs/CruiseApplications/PermissionDto.cs
@@ -5,10 +5,10 @@ namespace ResearchCruiseApp.Application.Models.DTOs.CruiseApplications;
 public class PermissionDto
 {
     [StringLength(1024)]
-    public string Description { get; init; } = null!;
+    public string? Description { get; init; }
 
     [StringLength(1024)]
-    public string Executive { get; init; } = null!;
+    public string? Executive { get; init; }
 
     public FileDto? Scan { get; set; }
 }

--- a/backend/ResearchCruiseApp/Application/Models/DTOs/CruiseApplications/PublicationDto.cs
+++ b/backend/ResearchCruiseApp/Application/Models/DTOs/CruiseApplications/PublicationDto.cs
@@ -6,15 +6,15 @@ public class PublicationDto
 
     public string Category { get; init; } = null!;
 
-    public string Doi { get; init; } = null!;
+    public string? Doi { get; init; }
 
-    public string Authors { get; init; } = null!;
+    public string? Authors { get; init; }
 
-    public string Title { get; init; } = null!;
+    public string? Title { get; init; }
 
-    public string Magazine { get; init; } = null!;
+    public string? Magazine { get; init; }
 
-    public string Year { get; init; } = null!;
+    public string? Year { get; init; }
 
     public string MinisterialPoints { get; init; } = null!;
 }

--- a/backend/ResearchCruiseApp/Application/Models/DTOs/CruiseApplications/SpubTaskDto.cs
+++ b/backend/ResearchCruiseApp/Application/Models/DTOs/CruiseApplications/SpubTaskDto.cs
@@ -2,9 +2,9 @@ namespace ResearchCruiseApp.Application.Models.DTOs.CruiseApplications;
 
 public class SpubTaskDto
 {
-    public string Name { get; init; } = null!;
+    public string? Name { get; init; }
 
-    public string YearFrom { get; init; } = null!;
+    public string? YearFrom { get; init; }
 
-    public string YearTo { get; init; } = null!;
+    public string? YearTo { get; init; }
 }

--- a/backend/ResearchCruiseApp/Application/Services/Factories/FormAInitValuesDtos/FormAInitValuesDtosFactory.cs
+++ b/backend/ResearchCruiseApp/Application/Services/Factories/FormAInitValuesDtos/FormAInitValuesDtosFactory.cs
@@ -178,6 +178,7 @@ public class FormAInitValuesDtosFactory(
                     formAGuestUnit.GuestUnit.Name
                 ) ?? []
             )
+            .OfType<string>()
             .Distinct()
             .ToList();
 

--- a/backend/ResearchCruiseApp/Application/UseCases/Users/DeleteUser/DeleteUserCommandHandler.cs
+++ b/backend/ResearchCruiseApp/Application/UseCases/Users/DeleteUser/DeleteUserCommandHandler.cs
@@ -15,8 +15,6 @@ public class DeleteUserCommandHandler(
         if (!await userPermissionVerifier.CanUserDeleteOtherUsers(request.Id))
             return Error.ForbiddenOperation();
 
-        var result = await identityService.DeleteUser(request.Id);
-
-        return result;
+        return await identityService.DeleteUser(request.Id, cancellationToken);
     }
 }

--- a/backend/ResearchCruiseApp/Application/UseCases/Users/ToggleUserRole/ToggleUserRoleHandler.cs
+++ b/backend/ResearchCruiseApp/Application/UseCases/Users/ToggleUserRole/ToggleUserRoleHandler.cs
@@ -21,7 +21,8 @@ public class ToggleUserRoleHandler(IIdentityService identityService)
             ? await identityService.AddRoleToUser(request.UserId, request.RoleToggleDto.RoleName)
             : await identityService.RemoveRoleFromUser(
                 request.UserId,
-                request.RoleToggleDto.RoleName
+                request.RoleToggleDto.RoleName,
+                cancellationToken
             );
 
         return result;

--- a/backend/ResearchCruiseApp/Application/UseCases/Users/UpdateUser/UpdateUserCommandHandler.cs
+++ b/backend/ResearchCruiseApp/Application/UseCases/Users/UpdateUser/UpdateUserCommandHandler.cs
@@ -17,8 +17,10 @@ public class UpdateUserCommandHandler(IIdentityService identityService)
         )
             return Error.InvalidArgument("Rola nie istnieje");
 
-        var result = await identityService.UpdateUser(request.UserId, request.UpdateUserFormDto);
-
-        return result;
+        return await identityService.UpdateUser(
+            request.UserId,
+            request.UpdateUserFormDto,
+            cancellationToken
+        );
     }
 }

--- a/backend/ResearchCruiseApp/Domain/Entities/Contract.cs
+++ b/backend/ResearchCruiseApp/Domain/Entities/Contract.cs
@@ -31,16 +31,21 @@ public class Contract : Entity, IEquatable<Contract>, IEquatableByExpression<Con
 
     public override int GetHashCode()
     {
-        var hashCode =
-            Category.GetHashCode() + InstitutionName?.GetHashCode()
-            ?? 0 + InstitutionUnit?.GetHashCode()
-            ?? 0 + InstitutionLocalization?.GetHashCode()
-            ?? 0 + Description?.GetHashCode()
-            ?? 0;
-
-        foreach (var file in Files)
+        var hashCode = HashCode.Combine(
+            Category,
+            InstitutionName,
+            InstitutionUnit,
+            InstitutionLocalization,
+            Description
+        );
+        if (Files != null)
         {
-            hashCode += file.FileName!.GetHashCode() + file.FileContent!.GetHashCode();
+            var sortedFiles = Files.OrderBy(f => f.FileName).ToList();
+
+            foreach (var file in sortedFiles)
+            {
+                hashCode = HashCode.Combine(hashCode, file.FileName, file.FileContent?.Length);
+            }
         }
 
         return hashCode;

--- a/backend/ResearchCruiseApp/Domain/Entities/CrewMember.cs
+++ b/backend/ResearchCruiseApp/Domain/Entities/CrewMember.cs
@@ -36,14 +36,16 @@ public class CrewMember : Entity, IEquatable<CrewMember>, IEquatableByExpression
 
     public override int GetHashCode()
     {
-        return Title.GetHashCode()
-            + FirstName.GetHashCode()
-            + LastName.GetHashCode()
-            + BirthPlace.GetHashCode()
-            + BirthDate.GetHashCode()
-            + DocumentNumber.GetHashCode()
-            + DocumentExpiryDate.GetHashCode()
-            + Institution.GetHashCode();
+        return HashCode.Combine(
+            Title,
+            FirstName,
+            LastName,
+            BirthPlace,
+            BirthDate,
+            DocumentNumber,
+            DocumentExpiryDate,
+            Institution
+        );
     }
 
     public bool Equals(CrewMember? other)

--- a/backend/ResearchCruiseApp/Domain/Entities/CruiseDayDetails.cs
+++ b/backend/ResearchCruiseApp/Domain/Entities/CruiseDayDetails.cs
@@ -35,12 +35,7 @@ public class CruiseDayDetails
 
     public override int GetHashCode()
     {
-        return Number.GetHashCode()
-            + Hours.GetHashCode()
-            + TaskName.GetHashCode()
-            + Region.GetHashCode()
-            + Position.GetHashCode()
-            + Comment.GetHashCode();
+        return HashCode.Combine(Number, Hours, TaskName, Region, Position, Comment);
     }
 
     public bool Equals(CruiseDayDetails? other)

--- a/backend/ResearchCruiseApp/Domain/Entities/GuestUnit.cs
+++ b/backend/ResearchCruiseApp/Domain/Entities/GuestUnit.cs
@@ -7,7 +7,7 @@ namespace ResearchCruiseApp.Domain.Entities;
 public class GuestUnit : Entity, IEquatable<GuestUnit>, IEquatableByExpression<GuestUnit>
 {
     [StringLength(1024)]
-    public string Name { get; init; } = null!;
+    public string? Name { get; init; }
 
     public List<FormAGuestUnit> FormAGuestUnits { get; init; } = [];
 
@@ -19,7 +19,7 @@ public class GuestUnit : Entity, IEquatable<GuestUnit>, IEquatableByExpression<G
 
     public override int GetHashCode()
     {
-        return Name.GetHashCode();
+        return HashCode.Combine(Name);
     }
 
     public bool Equals(GuestUnit? other)

--- a/backend/ResearchCruiseApp/Domain/Entities/Permission.cs
+++ b/backend/ResearchCruiseApp/Domain/Entities/Permission.cs
@@ -10,10 +10,10 @@ public class Permission : Entity, IEquatable<Permission>, IEquatableByExpression
     private byte[]? _scanContent;
 
     [StringLength(10240)]
-    public string Description { get; init; } = null!;
+    public string? Description { get; init; }
 
     [StringLength(1024)]
-    public string Executive { get; init; } = null!;
+    public string? Executive { get; init; }
 
     [StringLength(1024)]
     public string? ScanName
@@ -48,9 +48,7 @@ public class Permission : Entity, IEquatable<Permission>, IEquatableByExpression
 
     public override int GetHashCode()
     {
-        return Description.GetHashCode() + Executive.GetHashCode() + ScanName?.GetHashCode()
-            ?? 0 + ScanContent?.GetHashCode()
-            ?? 0;
+        return HashCode.Combine(Description, Executive, ScanName, ScanContent?.Length);
     }
 
     public bool Equals(Permission? other)

--- a/backend/ResearchCruiseApp/Domain/Entities/Port.cs
+++ b/backend/ResearchCruiseApp/Domain/Entities/Port.cs
@@ -17,7 +17,7 @@ public class Port : Entity, IEquatable<Port>, IEquatableByExpression<Port>
 
     public override int GetHashCode()
     {
-        return Name.GetHashCode();
+        return HashCode.Combine(Name);
     }
 
     public bool Equals(Port? other)

--- a/backend/ResearchCruiseApp/Domain/Entities/Publication.cs
+++ b/backend/ResearchCruiseApp/Domain/Entities/Publication.cs
@@ -10,19 +10,19 @@ public class Publication : Entity, IEquatable<Publication>, IEquatableByExpressi
     public string Category { get; init; } = null!;
 
     [StringLength(1024)]
-    public string Doi { get; init; } = null!;
+    public string? Doi { get; init; }
 
     [StringLength(1024)]
-    public string Authors { get; init; } = null!;
+    public string? Authors { get; init; }
 
     [StringLength(1024)]
-    public string Title { get; init; } = null!;
+    public string? Title { get; init; }
 
     [StringLength(1024)]
-    public string Magazine { get; init; } = null!;
+    public string? Magazine { get; init; }
 
     [StringLength(1024)]
-    public string Year { get; init; } = null!;
+    public string? Year { get; init; }
 
     [StringLength(1024)]
     public string MinisterialPoints { get; init; } = null!;
@@ -35,13 +35,7 @@ public class Publication : Entity, IEquatable<Publication>, IEquatableByExpressi
 
     public override int GetHashCode()
     {
-        return Category.GetHashCode()
-            + Doi.GetHashCode()
-            + Authors.GetHashCode()
-            + Title.GetHashCode()
-            + Magazine.GetHashCode()
-            + Year.GetHashCode()
-            + MinisterialPoints.GetHashCode();
+        return HashCode.Combine(Category, Doi, Authors, Title, Magazine, Year, MinisterialPoints);
     }
 
     public bool Equals(Publication? other)

--- a/backend/ResearchCruiseApp/Domain/Entities/ResearchEquipment.cs
+++ b/backend/ResearchCruiseApp/Domain/Entities/ResearchEquipment.cs
@@ -28,7 +28,7 @@ public class ResearchEquipment
 
     public override int GetHashCode()
     {
-        return Name.GetHashCode();
+        return HashCode.Combine(Name);
     }
 
     public bool Equals(ResearchEquipment? other)

--- a/backend/ResearchCruiseApp/Domain/Entities/ResearchTask.cs
+++ b/backend/ResearchCruiseApp/Domain/Entities/ResearchTask.cs
@@ -53,19 +53,23 @@ public class ResearchTask : Entity, IEquatable<ResearchTask>, IEquatableByExpres
 
     public override int GetHashCode()
     {
-        return Type.GetHashCode() + Title?.GetHashCode()
-            ?? 0 + Magazine?.GetHashCode()
-            ?? 0 + Author?.GetHashCode()
-            ?? 0 + Institution?.GetHashCode()
-            ?? 0 + Date?.GetHashCode()
-            ?? 0 + StartDate?.GetHashCode()
-            ?? 0 + EndDate?.GetHashCode()
-            ?? 0 + FinancingAmount?.GetHashCode()
-            ?? 0 + Description?.GetHashCode()
-            ?? 0 + FinancingApproved?.GetHashCode()
-            ?? 0 + SecuredAmount?.GetHashCode()
-            ?? 0 + MinisterialPoints?.GetHashCode()
-            ?? 0;
+        return HashCode.Combine(
+            Type,
+            Title,
+            Magazine,
+            Author,
+            Institution,
+            Date,
+            StartDate,
+            HashCode.Combine(
+                EndDate,
+                FinancingAmount,
+                Description,
+                FinancingApproved,
+                SecuredAmount,
+                MinisterialPoints
+            )
+        );
     }
 
     public bool Equals(ResearchTask? other)

--- a/backend/ResearchCruiseApp/Domain/Entities/SpubTask.cs
+++ b/backend/ResearchCruiseApp/Domain/Entities/SpubTask.cs
@@ -7,13 +7,13 @@ namespace ResearchCruiseApp.Domain.Entities;
 public class SpubTask : Entity, IEquatable<SpubTask>, IEquatableByExpression<SpubTask>
 {
     [StringLength(1024)]
-    public string Name { get; init; } = null!;
+    public string? Name { get; init; }
 
     [StringLength(1024)]
-    public string YearFrom { get; init; } = null!;
+    public string? YearFrom { get; init; }
 
     [StringLength(1024)]
-    public string YearTo { get; init; } = null!;
+    public string? YearTo { get; init; }
 
     public List<FormASpubTask> FormASpubTasks { get; init; } = [];
 
@@ -23,7 +23,7 @@ public class SpubTask : Entity, IEquatable<SpubTask>, IEquatableByExpression<Spu
 
     public override int GetHashCode()
     {
-        return YearFrom.GetHashCode() + YearTo.GetHashCode() + Name.GetHashCode();
+        return HashCode.Combine(YearFrom, YearTo, Name);
     }
 
     public bool Equals(SpubTask? other)

--- a/backend/ResearchCruiseApp/Infrastructure/Persistence/Migrations/20260213144221_MakeFormAFieldsNullableSoDraftsCanAlwaysBeSaved.Designer.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Persistence/Migrations/20260213144221_MakeFormAFieldsNullableSoDraftsCanAlwaysBeSaved.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ResearchCruiseApp.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using ResearchCruiseApp.Infrastructure.Persistence;
 namespace ResearchCruiseApp.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260213144221_MakeFormAFieldsNullableSoDraftsCanAlwaysBeSaved")]
+    partial class MakeFormAFieldsNullableSoDraftsCanAlwaysBeSaved
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/ResearchCruiseApp/Infrastructure/Persistence/Migrations/20260213144221_MakeFormAFieldsNullableSoDraftsCanAlwaysBeSaved.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Persistence/Migrations/20260213144221_MakeFormAFieldsNullableSoDraftsCanAlwaysBeSaved.cs
@@ -1,0 +1,282 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ResearchCruiseApp.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeFormAFieldsNullableSoDraftsCanAlwaysBeSaved : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "YearTo",
+                table: "SpubTasks",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "YearFrom",
+                table: "SpubTasks",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "SpubTasks",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Year",
+                table: "Publications",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Publications",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Magazine",
+                table: "Publications",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Doi",
+                table: "Publications",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Authors",
+                table: "Publications",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Executive",
+                table: "Permissions",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Permissions",
+                type: "nvarchar(max)",
+                maxLength: 10240,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldMaxLength: 10240
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "GuestUnits",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "YearTo",
+                table: "SpubTasks",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "YearFrom",
+                table: "SpubTasks",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "SpubTasks",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Year",
+                table: "Publications",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Publications",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Magazine",
+                table: "Publications",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Doi",
+                table: "Publications",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Authors",
+                table: "Publications",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Executive",
+                table: "Permissions",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Permissions",
+                type: "nvarchar(max)",
+                maxLength: 10240,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldMaxLength: 10240,
+                oldNullable: true
+            );
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "GuestUnits",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024,
+                oldNullable: true
+            );
+        }
+    }
+}

--- a/backend/ResearchCruiseApp/Infrastructure/Services/Identity/IdentityService.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Services/Identity/IdentityService.cs
@@ -8,7 +8,9 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using NeoSmart.Utils;
+using ResearchCruiseApp.Application.Common.Constants;
 using ResearchCruiseApp.Application.ExternalServices;
+using ResearchCruiseApp.Application.ExternalServices.Persistence;
 using ResearchCruiseApp.Application.Models.Common.ServiceResult;
 using ResearchCruiseApp.Application.Models.DTOs.Account;
 using ResearchCruiseApp.Application.Models.DTOs.Users;
@@ -22,7 +24,8 @@ public class IdentityService(
     IRandomGenerator randomGenerator,
     ICurrentUserService currentUserService,
     IMapper mapper,
-    IConfiguration configuration
+    IConfiguration configuration,
+    IUnitOfWork unitOfWork
 ) : IIdentityService
 {
     public async Task<UserDto?> GetUserDtoById(Guid id)
@@ -287,14 +290,21 @@ public class IdentityService(
         return result.ToApplicationResult();
     }
 
-    public async Task<Result> RemoveRoleFromUser(Guid userId, string roleName)
+    public async Task<Result> RemoveRoleFromUser(
+        Guid userId,
+        string roleName,
+        CancellationToken cancellationToken = default
+    )
     {
-        var user = await userManager.FindByIdAsync(userId.ToString());
-        if (user is null)
-            return Error.ResourceNotFound();
+        if (roleName != RoleName.Administrator)
+            return await RemoveRoleFromUserCore(userId, roleName);
 
-        var result = await userManager.RemoveFromRoleAsync(user, roleName);
-        return result.ToApplicationResult();
+        return await ExecuteAdminInvariantGuarded(
+            userId,
+            "Nie można usunąć roli ostatniego administratora",
+            () => RemoveRoleFromUserCore(userId, roleName),
+            cancellationToken
+        );
     }
 
     public async Task<IList<string>> GetUserRolesNames(Guid userId)
@@ -324,7 +334,48 @@ public class IdentityService(
         return roleManager.Roles.Select(role => role.Name).ToListAsync(cancellationToken);
     }
 
-    public async Task<Result> DeleteUser(Guid userId)
+    public async Task<Result> DeleteUser(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var userRoles = await GetUserRolesNames(userId);
+        if (!userRoles.Contains(RoleName.Administrator))
+            return await DeleteUserCore(userId);
+
+        return await ExecuteAdminInvariantGuarded(
+            userId,
+            "Nie można usunąć ostatniego administratora",
+            () => DeleteUserCore(userId),
+            cancellationToken
+        );
+    }
+
+    public async Task<Result> UpdateUser(
+        Guid userId,
+        UpdateUserFormDto updateUserFormDto,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (updateUserFormDto.Role is null || updateUserFormDto.Role == RoleName.Administrator)
+            return await UpdateUserCore(userId, updateUserFormDto);
+
+        return await ExecuteAdminInvariantGuarded(
+            userId,
+            "Nie można zmienić roli ostatniego administratora",
+            () => UpdateUserCore(userId, updateUserFormDto),
+            cancellationToken
+        );
+    }
+
+    private async Task<Result> RemoveRoleFromUserCore(Guid userId, string roleName)
+    {
+        var user = await userManager.FindByIdAsync(userId.ToString());
+        if (user is null)
+            return Error.ResourceNotFound();
+
+        var result = await userManager.RemoveFromRoleAsync(user, roleName);
+        return result.ToApplicationResult();
+    }
+
+    private async Task<Result> DeleteUserCore(Guid userId)
     {
         var user = await userManager.FindByIdAsync(userId.ToString());
         if (user is null)
@@ -335,7 +386,37 @@ public class IdentityService(
         return identityResult.Succeeded ? Result.Empty : identityResult.ToApplicationResult();
     }
 
-    public async Task<Result> UpdateUser(Guid userId, UpdateUserFormDto updateUserFormDto)
+    private async Task<int> GetUsersCountInRole(string roleName)
+    {
+        var usersInRole = await userManager.GetUsersInRoleAsync(roleName);
+        return usersInRole.Count;
+    }
+
+    private async Task<Result> ExecuteAdminInvariantGuarded(
+        Guid userId,
+        string conflictMessage,
+        Func<Task<Result>> mutation,
+        CancellationToken cancellationToken
+    )
+    {
+        return await unitOfWork.ExecuteIsolated(
+            async () =>
+            {
+                var userRoles = await GetUserRolesNames(userId);
+                if (userRoles.Contains(RoleName.Administrator))
+                {
+                    var adminCount = await GetUsersCountInRole(RoleName.Administrator);
+                    if (adminCount <= 1)
+                        return Error.Conflict(conflictMessage);
+                }
+
+                return await mutation();
+            },
+            cancellationToken
+        );
+    }
+
+    private async Task<Result> UpdateUserCore(Guid userId, UpdateUserFormDto updateUserFormDto)
     {
         var user = await userManager.FindByIdAsync(userId.ToString());
         if (user is null)

--- a/docker/compose.staging-app.yaml
+++ b/docker/compose.staging-app.yaml
@@ -2,6 +2,7 @@ services:
   backend:
     container_name: researchcruiseapp-backend
     image: ghcr.io/vv01t3k/researchcruiseapp/backend:staging
+    restart: unless-stopped
     environment:
       - Database__SeedAutomatically=${DATABASE_SEED_AUTOMATICALLY:-true}
       - Database__MigrateAutomatically=${DATABASE_MIGRATE_AUTOMATICALLY:-true}
@@ -15,6 +16,7 @@ services:
       - backend
     container_name: researchcruiseapp-frontend
     image: ghcr.io/vv01t3k/researchcruiseapp/frontend:staging
+    restart: unless-stopped
     expose:
       - 8080
     networks:

--- a/docker/compose.staging-db.yaml
+++ b/docker/compose.staging-db.yaml
@@ -2,6 +2,7 @@ services:
   db:
     image: mcr.microsoft.com/mssql/server:2022-latest
     container_name: researchcruiseapp-db
+    restart: unless-stopped
     environment:
       SA_PASSWORD: "p@ssw0rd"
       ACCEPT_EULA: "Y"

--- a/docker/compose.staging-grafana.yaml
+++ b/docker/compose.staging-grafana.yaml
@@ -2,6 +2,7 @@ services:
   grafana:
     container_name: researchcruiseapp-grafana
     image: grafana/grafana:12.0.0
+    restart: unless-stopped
     volumes:
       - ./config/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:ro
       - ./config/grafana-dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml:ro
@@ -28,6 +29,7 @@ services:
   alloy:
     container_name: researchcruiseapp-alloy
     image: grafana/alloy:v1.8.3
+    restart: unless-stopped
     volumes:
       - ./config/config.alloy:/etc/alloy/config.alloy:ro
     networks:
@@ -41,12 +43,14 @@ services:
   loki:
     container_name: researchcruiseapp-loki
     image: grafana/loki:3.4.2
+    restart: unless-stopped
     networks:
       - researchcruiseapp-network
 
   tempo:
     container_name: researchcruiseapp-tempo
     image: grafana/tempo:2.7.1
+    restart: unless-stopped
     volumes:
       - ./config/tempo.yaml:/etc/tempo.yaml:ro
     command:
@@ -60,6 +64,7 @@ services:
   prometheus:
     container_name: researchcruiseapp-prometheus
     image: prom/prometheus:v3.3.1
+    restart: unless-stopped
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus

--- a/docker/compose.staging-otel.yaml
+++ b/docker/compose.staging-otel.yaml
@@ -2,6 +2,7 @@ services:
   backend:
     container_name: researchcruiseapp-backend
     image: ghcr.io/vv01t3k/researchcruiseapp/backend:staging
+    restart: unless-stopped
     environment:
       Database__SeedAutomatically: ${DATABASE_SEED_AUTOMATICALLY:-true}
       Database__MigrateAutomatically: ${DATABASE_MIGRATE_AUTOMATICALLY:-true}
@@ -17,6 +18,7 @@ services:
       - backend
     container_name: researchcruiseapp-frontend
     image: ghcr.io/vv01t3k/researchcruiseapp/frontend:staging
+    restart: unless-stopped
     environment:
       GRAFANA_FARO_URL: http://alloy:12347/
     expose:

--- a/frontend/src/modules/core/lib/utils.ts
+++ b/frontend/src/modules/core/lib/utils.ts
@@ -94,10 +94,11 @@ export function getErrors(field: AnyFieldMeta, hasFormBeenSubmitted: boolean = t
     : field.errors.map(extractErrorMessage);
 }
 
-function scrollToError(delay: number = 0): void {
+function scrollToError(delay: number = 0, fallbackElement?: Element | null): void {
   const scroll = () => {
     const errorElement = document.querySelector('[data-error="true"]');
-    errorElement?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    const targetElement = errorElement ?? fallbackElement;
+    targetElement?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   };
 
   if (delay > 0) {
@@ -114,21 +115,24 @@ export function navigateToFirstError(
 ): void {
   const firstError = form ? getFirstFormError(form, fieldToSectionMapping) : null;
   const sectionNumber = firstError?.sectionNumber;
+  const fieldElement =
+    firstError?.fieldName !== undefined ? document.getElementsByName(firstError.fieldName).item(0) : null;
 
   // Find and expand the accordion section containing the error
-  const accordionButtons = Array.from(document.querySelectorAll('h2 button'));
+  const accordionButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('h2 button'));
   const targetButton = accordionButtons.find((button) => {
     const title = button.querySelector('span')?.textContent || '';
     return title.includes(`${sectionNumber}.`);
   });
 
   const isExpanded = targetButton?.hasAttribute('data-panel-open');
+  const fallbackElement = fieldElement ?? targetButton;
 
-  if (!isExpanded) {
-    (targetButton as HTMLButtonElement).click();
-    scrollToError(50);
+  if (targetButton instanceof HTMLButtonElement && !isExpanded) {
+    targetButton.click();
+    scrollToError(150, fallbackElement);
   } else {
-    scrollToError();
+    scrollToError(0, fallbackElement);
   }
 }
 

--- a/frontend/src/modules/cruise-applications/components/common/CruiseApplicationDropdownElementSelectorButton.tsx
+++ b/frontend/src/modules/cruise-applications/components/common/CruiseApplicationDropdownElementSelectorButton.tsx
@@ -32,7 +32,10 @@ export function CruiseApplicationDropdownElementSelectorButton({
   const [expanded, setExpanded] = useState(false);
   const [searchValue, setSearchValue] = useState('');
 
-  const filteredOptions = options.filter((option) => option.value.toLowerCase().includes(searchValue.toLowerCase()));
+  const filteredOptions = options.filter(
+    (option) =>
+      option.value && option.value.trim().length > 0 && option.value.toLowerCase().includes(searchValue.toLowerCase())
+  );
 
   return (
     <Popover.Root open={expanded} onOpenChange={setExpanded} modal={false}>

--- a/frontend/src/modules/cruise-applications/components/formA/FormAPublicationsSection.tsx
+++ b/frontend/src/modules/cruise-applications/components/formA/FormAPublicationsSection.tsx
@@ -269,47 +269,56 @@ export function FormAPublicationsSection() {
                   </CruiseApplicationDropdownElementSelectorButton>,
                   <CruiseApplicationDropdownElementSelectorButton
                     key="historical"
-                    options={groupBy(initValues.historicalPublications, (x) => x.category).flatMap(
-                      ([category, publications]) => [
-                        ...[
-                          {
-                            value: category,
-                            content: (
-                              <div className="my-2 w-full rounded-lg px-2 text-center text-sm text-gray-500">
-                                {getPublicationCategoryLabel(category as PublicationCategory)}
-                              </div>
-                            ),
-                          },
-                        ],
-                        ...publications.map((publication) => ({
-                          value: JSON.stringify(publication),
+                    // dont show options with empty fields
+                    options={groupBy(
+                      initValues.historicalPublications.filter(
+                        (publication) =>
+                          publication.doi &&
+                          publication.authors &&
+                          publication.title &&
+                          publication.magazine &&
+                          publication.year
+                      ),
+                      (x) => x.category
+                    ).flatMap(([category, publications]) => [
+                      ...[
+                        {
+                          value: category,
                           content: (
-                            <div className="w-full cursor-pointer rounded-lg px-2 inset-ring-blue-500 hover:bg-gray-100 focus:inset-ring-2">
-                              <div>
-                                <strong>DOI:</strong> {publication.doi}
-                              </div>
-                              <div>
-                                <strong>Autorzy:</strong> {publication.authors}
-                              </div>
-                              <div>
-                                <strong>Tytuł:</strong> {publication.title}
-                              </div>
-                              <div>
-                                <strong>Czasopismo:</strong> {publication.magazine}
-                              </div>
-                              <div>
-                                <strong>Rok:</strong> {publication.year}
-                              </div>
+                            <div className="my-2 w-full rounded-lg px-2 text-center text-sm text-gray-500">
+                              {getPublicationCategoryLabel(category as PublicationCategory)}
                             </div>
                           ),
-                          onClick: () => {
-                            field.pushValue(publication);
-                            field.handleChange((prev: PublicationDto[]) => prev);
-                            field.handleBlur();
-                          },
-                        })),
-                      ]
-                    )}
+                        },
+                      ],
+                      ...publications.map((publication) => ({
+                        value: JSON.stringify(publication),
+                        content: (
+                          <div className="w-full cursor-pointer rounded-lg px-2 inset-ring-blue-500 hover:bg-gray-100 focus:inset-ring-2">
+                            <div>
+                              <strong>DOI:</strong> {publication.doi}
+                            </div>
+                            <div>
+                              <strong>Autorzy:</strong> {publication.authors}
+                            </div>
+                            <div>
+                              <strong>Tytuł:</strong> {publication.title}
+                            </div>
+                            <div>
+                              <strong>Czasopismo:</strong> {publication.magazine}
+                            </div>
+                            <div>
+                              <strong>Rok:</strong> {publication.year}
+                            </div>
+                          </div>
+                        ),
+                        onClick: () => {
+                          field.pushValue(publication);
+                          field.handleChange((prev: PublicationDto[]) => prev);
+                          field.handleBlur();
+                        },
+                      })),
+                    ])}
                     variant="primaryOutline"
                     disabled={isReadonly}
                     data-testid="form-a-add-historical-publication-btn"

--- a/frontend/src/modules/cruise-applications/components/formA/FormASPUBTasksSection.tsx
+++ b/frontend/src/modules/cruise-applications/components/formA/FormASPUBTasksSection.tsx
@@ -151,15 +151,17 @@ export function FormASPUBTasksSection() {
                   </AppButton>,
                   <CruiseApplicationDropdownElementSelectorButton
                     key="historical"
-                    options={initValues.historicalSpubTasks.map((task) => ({
-                      value: JSON.stringify(task),
-                      content: `${task.name} (${task.yearFrom} - ${task.yearTo})`,
-                      onClick: () => {
-                        field.pushValue(task);
-                        field.handleChange((prev: SpubTaskDto[]) => prev);
-                        field.handleBlur();
-                      },
-                    }))}
+                    options={initValues.historicalSpubTasks
+                      .filter((task) => task.name && task.yearFrom && task.yearTo) // dont show options with empty fields
+                      .map((task) => ({
+                        value: JSON.stringify(task),
+                        content: `${task.name ?? ''} (${task.yearFrom ?? ''} - ${task.yearTo ?? ''})`,
+                        onClick: () => {
+                          field.pushValue(task);
+                          field.handleChange((prev: SpubTaskDto[]) => prev);
+                          field.handleBlur();
+                        },
+                      }))}
                     variant="primaryOutline"
                     disabled={isReadonly}
                     data-testid="form-a-add-historical-spub-task-btn"

--- a/frontend/src/modules/cruise-applications/components/formC/FormCSPUBTasksSection.tsx
+++ b/frontend/src/modules/cruise-applications/components/formC/FormCSPUBTasksSection.tsx
@@ -3,7 +3,7 @@ import { ColumnDef } from '@tanstack/react-table';
 
 import { AppAccordion } from '@/core/components/AppAccordion';
 import { AppButton } from '@/core/components/AppButton';
-import { AppInput } from '@/core/components/inputs/AppInput';
+import { AppDropdownInput } from '@/core/components/inputs/AppDropdownInput';
 import { AppYearPickerInput } from '@/core/components/inputs/dates/AppYearPickerInput';
 import { AppInputErrorsList } from '@/core/components/inputs/parts/AppInputErrorsList';
 import { AppTable } from '@/core/components/table/AppTable';
@@ -84,12 +84,16 @@ export function FormCSPUBTasksSection() {
           <form.Field
             name={`spubTasks[${row.index}].name`}
             children={(field) => (
-              <AppInput
+              <AppDropdownInput
                 name={field.name}
-                value={field.state.value}
-                onChange={field.handleChange}
+                value={field.state.value as string}
+                onChange={(e) => field.handleChange(e as string)}
                 onBlur={field.handleBlur}
                 errors={getErrors(field.state.meta, hasFormBeenSubmitted)}
+                allOptions={formAInitValues?.standardSpubTasks.map((taskName) => ({
+                  value: taskName,
+                  inlineLabel: taskName,
+                }))}
                 disabled={isReadonly}
               />
             )}

--- a/frontend/src/modules/cruise-applications/models/CruiseDayDetailsDto.ts
+++ b/frontend/src/modules/cruise-applications/models/CruiseDayDetailsDto.ts
@@ -15,5 +15,5 @@ export const CruiseDayDetailsDtoValidationSchema = z.object({
   taskName: z.string().nonempty('Nazwa zadania jest wymagana'),
   region: z.string().nonempty('Region jest wymagany'),
   position: z.string().nonempty('Pozycja jest wymagana'),
-  comment: z.string().nonempty('Komentarz jest wymagany').max(10240, 'Komentarz nie może być dłuższy niż 10240 znaków'),
+  comment: z.string().max(1024, 'Komentarz nie może być dłuższy niż 1024 znaków'),
 });

--- a/frontend/src/modules/cruise-applications/pages/FormAPage.tsx
+++ b/frontend/src/modules/cruise-applications/pages/FormAPage.tsx
@@ -46,7 +46,12 @@ export function FormAPage() {
       ? {
           ...formA.data,
           deputyManagerId: formA.data.deputyManagerId ?? '',
-          permissions: formA.data.permissions.map((p) => ({ ...p, scan: undefined })),
+          permissions: formA.data.permissions.map((p) => ({
+            ...p,
+            description: p.description ?? '',
+            executive: p.executive ?? '',
+            scan: undefined,
+          })),
           acceptablePeriod: formA.data.acceptablePeriod?.length === 0 ? '' : (formA.data.acceptablePeriod ?? ''),
           optimalPeriod: formA.data.optimalPeriod?.length === 0 ? '' : (formA.data.optimalPeriod ?? ''),
           precisePeriodStart: formA.data.precisePeriodStart ?? '',
@@ -59,6 +64,9 @@ export function FormAPage() {
                 : 'period',
           contracts: mapNullsToEmptyStrings(formA.data.contracts),
           researchTasks: mapNullsToEmptyStrings(formA.data.researchTasks),
+          guestTeams: mapNullsToEmptyStrings(formA.data.guestTeams),
+          publications: mapNullsToEmptyStrings(formA.data.publications),
+          spubTasks: mapNullsToEmptyStrings(formA.data.spubTasks),
         }
       : {
           id: undefined,

--- a/frontend/src/modules/cruise-applications/pages/FormBPage.tsx
+++ b/frontend/src/modules/cruise-applications/pages/FormBPage.tsx
@@ -16,6 +16,7 @@ import {
   useRevertFormBToEditMutation,
   useUpdateFormBMutation,
 } from '@/cruise-applications/hooks/FormBApiHooks';
+import { CruiseDayDetailsDtoValidationSchema } from '@/cruise-applications/models/CruiseDayDetailsDto';
 import { FormBDto } from '@/cruise-applications/models/FormBDto';
 
 export function FormBPage() {
@@ -71,7 +72,7 @@ export function FormBPage() {
 
     await form.validate('change');
 
-    if (!form.state.canSubmit) {
+    if (!form.state.isValid) {
       toast.error(getFormErrorMessage(form, FORM_B_FIELD_TO_SECTION));
       navigateToFirstError(form, FORM_B_FIELD_TO_SECTION);
       return;
@@ -112,6 +113,19 @@ export function FormBPage() {
   }
 
   async function handleDraftSave() {
+    const cruiseDaysDetails = form.state.values.cruiseDaysDetails;
+    const hasCommentTooLong = cruiseDaysDetails?.some(
+      (day) => !CruiseDayDetailsDtoValidationSchema.shape.comment.safeParse(day.comment).success
+    );
+
+    if (hasCommentTooLong) {
+      setHasFormBeenSubmitted(true);
+      await form.validate('change');
+      toast.error('Formularz błędny w sekcji nr 13:\nUwagi nie mogą być dłuższe niż 1024 znaków');
+      navigateToFirstError(form, { cruiseDaysDetails: 13 });
+      return;
+    }
+
     const loading = toast.loading('Zapisywanie wersji roboczej formularza...');
     await updateMutation.mutateAsync(
       {

--- a/frontend/src/modules/usermanagement/components/GroupActionSection.tsx
+++ b/frontend/src/modules/usermanagement/components/GroupActionSection.tsx
@@ -7,6 +7,8 @@ import React from 'react';
 
 import { AppAlert } from '@/core/components/AppAlert';
 import { AppButton } from '@/core/components/AppButton';
+import { toast } from '@/core/components/layout/toast';
+import { Role } from '@/core/models/Role';
 import { User } from '@/core/models/User';
 import {
   useAcceptUserMutation,
@@ -16,12 +18,13 @@ import {
 
 type Props = {
   selectedUsers: User[];
+  allUsers: User[];
 
   allowToRemoveUsers: boolean;
 
   close: () => void;
 };
-export function GroupActionSection({ selectedUsers, allowToRemoveUsers, close }: Props) {
+export function GroupActionSection({ selectedUsers, allUsers, allowToRemoveUsers, close }: Props) {
   const [deletionConfirmed, setDeletionConfirmed] = React.useState(false);
   const [submitError, setSubmitError] = React.useState<string | undefined>(undefined);
 
@@ -33,6 +36,14 @@ export function GroupActionSection({ selectedUsers, allowToRemoveUsers, close }:
   async function handleDeleteSelectedUsers() {
     if (!deletionConfirmed) {
       setDeletionConfirmed(true);
+      return;
+    }
+
+    const selectedIds = new Set(selectedUsers.map((u) => u.id));
+    const remainingAdmins = allUsers.filter((u) => !selectedIds.has(u.id) && u.roles.includes(Role.Administrator));
+    if (remainingAdmins.length === 0) {
+      toast.error('Po usunięciu zaznaczonych użytkowników musi istnieć co najmniej jeden admin');
+      setDeletionConfirmed(false);
       return;
     }
 

--- a/frontend/src/modules/usermanagement/components/UserEditForm.tsx
+++ b/frontend/src/modules/usermanagement/components/UserEditForm.tsx
@@ -137,6 +137,14 @@ export function UserEditForm({ user, allUsers, allowedRoles, allowToRemoveUsers,
       setDeletionConfirmed(true);
       return;
     }
+
+    const remainingAdmins = allUsers.filter((u) => u.id !== user.id && u.roles.includes(Role.Administrator));
+    if (remainingAdmins.length === 0) {
+      toast.error('Musi istnieć co najmniej jeden admin');
+      setDeletionConfirmed(false);
+      return;
+    }
+
     const loading = toast.loading('Usuwanie użytkownika...');
     try {
       await deleteUserMutation.mutateAsync(user.id);

--- a/frontend/src/modules/usermanagement/pages/UserManagementPage.tsx
+++ b/frontend/src/modules/usermanagement/pages/UserManagementPage.tsx
@@ -176,6 +176,7 @@ export function UserManagementPage() {
       >
         <GroupActionSection
           selectedUsers={usersQuery.data.filter((user) => selectedUsers[user.id])}
+          allUsers={usersQuery.data}
           allowToRemoveUsers={currentUserRole === Role.Administrator || currentUserRole === Role.ShipOwner}
           close={() => handleModalClose()}
         />

--- a/frontend/tests/fixtures/pages/formC/FormCSPUBTasksSection.ts
+++ b/frontend/tests/fixtures/pages/formC/FormCSPUBTasksSection.ts
@@ -1,5 +1,5 @@
 import type { Locator, Page } from '@playwright/test';
-import { FormDropdown, FormInput, locateSectionByTestId } from '@tests/utils/form-filling-utils';
+import { FormDropdown, locateSectionByTestId } from '@tests/utils/form-filling-utils';
 
 import { FormCPage } from './formCPage';
 
@@ -36,7 +36,7 @@ export class FormCSPUBTasksSection {
         variant: 'menu-with-buttons',
         errors: { required: rowLocator.getByText('Rok zakończenia jest wymagany') },
       }),
-      nameInput: new FormInput(rowLocator.locator('td').nth(3).getByRole('textbox').first(), {
+      nameDropdown: new FormDropdown(rowLocator.locator('td').nth(3).getByRole('combobox').first(), {
         errors: { required: rowLocator.getByText('Nazwa jest wymagana') },
       }),
       deleteButton: rowLocator.locator('td').nth(4).getByRole('button'),

--- a/frontend/tests/formB.spec.ts
+++ b/frontend/tests/formB.spec.ts
@@ -152,6 +152,7 @@ test.describe('cruise details section tests', () => {
     const cruiseDetailsSection = formBPage.sections.cruiseDetailsSection;
     await cruiseDetailsSection.addEquipmentButton.click();
     const equipmentRow = cruiseDetailsSection.equipmentRow('first');
+    const currentDay = String(await formBPage.page.evaluate(() => new Date().getDate()));
 
     await formBPage.submitForm();
     await expect(formBPage.submissionApprovedMessage).toBeHidden();
@@ -166,9 +167,9 @@ test.describe('cruise details section tests', () => {
     await expect(equipmentRow.fromDateDropdown.errors.required).toBeVisible();
     await expect(equipmentRow.toDateDropdown.errors.required).toBeVisible();
 
-    await equipmentRow.fromDateDropdown.selectOption('11');
+    await equipmentRow.fromDateDropdown.selectOption(currentDay);
     await expect(equipmentRow.fromDateDropdown.errors.required).toBeHidden();
-    await equipmentRow.toDateDropdown.selectOption('13');
+    await equipmentRow.toDateDropdown.selectOption(currentDay);
     await expect(equipmentRow.toDateDropdown.errors.required).toBeHidden();
 
     await formBPage.submitForm({ expectedResult: 'valid' });
@@ -199,6 +200,7 @@ test.describe('cruise details section tests', () => {
     const cruiseDetailsSection = formBPage.sections.cruiseDetailsSection;
     await cruiseDetailsSection.addPortButton.click();
     const portRow = cruiseDetailsSection.portRow('first');
+    const currentDay = String(await formBPage.page.evaluate(() => new Date().getDate()));
 
     await formBPage.submitForm();
     await expect(formBPage.submissionApprovedMessage).toBeHidden();
@@ -213,9 +215,9 @@ test.describe('cruise details section tests', () => {
     await expect(portRow.fromDateDropdown.errors.required).toBeVisible();
     await expect(portRow.toDateDropdown.errors.required).toBeVisible();
 
-    await portRow.fromDateDropdown.selectOption('11');
+    await portRow.fromDateDropdown.selectOption(currentDay);
     await expect(portRow.fromDateDropdown.errors.required).toBeHidden();
-    await portRow.toDateDropdown.selectOption('13');
+    await portRow.toDateDropdown.selectOption(currentDay);
     await expect(portRow.toDateDropdown.errors.required).toBeHidden();
 
     await formBPage.submitForm({ expectedResult: 'valid' });
@@ -234,7 +236,7 @@ test.describe('cruise day details section tests', () => {
     await formBPage.submitForm();
     await expect(formBPage.submissionApprovedMessage).toBeHidden();
 
-    const inputFields = [taskRow.nameInput, taskRow.regionInput, taskRow.positionInput, taskRow.commentInput];
+    const inputFields = [taskRow.nameInput, taskRow.regionInput, taskRow.positionInput];
 
     for (const inputField of inputFields) {
       await touchInput(inputField);

--- a/frontend/tests/formC.spec.ts
+++ b/frontend/tests/formC.spec.ts
@@ -192,15 +192,14 @@ test.describe('SPUB tasks section tests', () => {
     await spubTasksSection.addNewTaskButton.click();
     const taskRow = spubTasksSection.taskRow('first');
 
-    await touchInput(taskRow.nameInput);
-    await expect(taskRow.nameInput.errors.required).toBeVisible();
-
-    await taskRow.nameInput.fill('Jakieś zadanie');
-    await expect(taskRow.nameInput.errors.required).toBeHidden();
-
     await formCPage.submitForm({ expectedResult: 'invalid' });
+    await expect(taskRow.nameDropdown.errors.required).toBeVisible();
     await expect(taskRow.startYearDropdown.errors.required).toBeVisible();
     await expect(taskRow.endYearDropdown.errors.required).toBeVisible();
+
+    await taskRow.nameDropdown.dropdown.click();
+    await formCPage.page.getByRole('option').first().click();
+    await expect(taskRow.nameDropdown.errors.required).toBeHidden();
 
     await taskRow.startYearDropdown.selectOption('2023');
     await expect(taskRow.startYearDropdown.errors.required).toBeHidden();
@@ -221,6 +220,7 @@ test.describe('cruise details section tests', () => {
     const cruiseDetailsSection = formCPage.sections.cruiseDetailsSection;
     await cruiseDetailsSection.addEquipmentButton.click();
     const equipmentRow = cruiseDetailsSection.equipmentRow('first');
+    const currentDay = String(await formCPage.page.evaluate(() => new Date().getDate()));
 
     await formCPage.submitForm();
     await expect(formCPage.submissionApprovedMessage).toBeHidden();
@@ -235,9 +235,9 @@ test.describe('cruise details section tests', () => {
     await expect(equipmentRow.fromDateDropdown.errors.required).toBeVisible();
     await expect(equipmentRow.toDateDropdown.errors.required).toBeVisible();
 
-    await equipmentRow.fromDateDropdown.selectOption('11');
+    await equipmentRow.fromDateDropdown.selectOption(currentDay);
     await expect(equipmentRow.fromDateDropdown.errors.required).toBeHidden();
-    await equipmentRow.toDateDropdown.selectOption('13');
+    await equipmentRow.toDateDropdown.selectOption(currentDay);
     await expect(equipmentRow.toDateDropdown.errors.required).toBeHidden();
 
     await formCPage.submitForm({ expectedResult: 'valid' });
@@ -268,6 +268,7 @@ test.describe('cruise details section tests', () => {
     const cruiseDetailsSection = formCPage.sections.cruiseDetailsSection;
     await cruiseDetailsSection.addPortButton.click();
     const portRow = cruiseDetailsSection.portRow('first');
+    const currentDay = String(await formCPage.page.evaluate(() => new Date().getDate()));
 
     await formCPage.submitForm();
     await expect(formCPage.submissionApprovedMessage).toBeHidden();
@@ -282,9 +283,9 @@ test.describe('cruise details section tests', () => {
     await expect(portRow.fromDateDropdown.errors.required).toBeVisible();
     await expect(portRow.toDateDropdown.errors.required).toBeVisible();
 
-    await portRow.fromDateDropdown.selectOption('11');
+    await portRow.fromDateDropdown.selectOption(currentDay);
     await expect(portRow.fromDateDropdown.errors.required).toBeHidden();
-    await portRow.toDateDropdown.selectOption('13');
+    await portRow.toDateDropdown.selectOption(currentDay);
     await expect(portRow.toDateDropdown.errors.required).toBeHidden();
 
     await formCPage.submitForm({ expectedResult: 'valid' });
@@ -303,7 +304,7 @@ test.describe('cruise day details section tests', () => {
     await formCPage.submitForm();
     await expect(formCPage.submissionApprovedMessage).toBeHidden();
 
-    const inputFields = [taskRow.nameInput, taskRow.regionInput, taskRow.positionInput, taskRow.commentInput];
+    const inputFields = [taskRow.nameInput, taskRow.regionInput, taskRow.positionInput];
 
     for (const inputField of inputFields) {
       await touchInput(inputField);

--- a/frontend/tests/utils/form-filling-utils.ts
+++ b/frontend/tests/utils/form-filling-utils.ts
@@ -44,8 +44,23 @@ export class FormDropdown<TErrors extends Record<string, Locator> = Record<strin
       await this.page.waitForTimeout(100);
     } else if (this.variant === 'datetime-picker') {
       // for now, only day selection is supported
-      const menu = this.page.getByRole('menu');
-      await menu.getByRole('button', { name: itemText, exact: true }).click();
+      const menu = this.page.getByRole('menu').last();
+      const dayButtons = menu.getByRole('button', { name: itemText, exact: true });
+      const dayButtonsCount = await dayButtons.count();
+      let selected = false;
+
+      for (let i = 0; i < dayButtonsCount; i++) {
+        const dayButton = dayButtons.nth(i);
+        if (await dayButton.isEnabled()) {
+          await dayButton.click();
+          selected = true;
+          break;
+        }
+      }
+
+      if (!selected) {
+        throw new Error(`Could not find enabled datetime-picker day button: ${itemText}`);
+      }
       // Click on main content area to close the datetime picker (triggers useOutsideClickDetection)
       await this.page.getByTestId('main-content').click({ position: { x: 1, y: 1 } });
       await expect(menu).toBeHidden();

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "db:down": "docker compose -f docker/docker-compose.infra.yml down",
     "db:del": "bun db:down && (docker volume rm researchcruiseapp_researchcruiseapp-db || true) && rm admin.log || true",
     "dot:start": "cd backend && bun run start",
-    "admin:pass": "bun db:del && sleep 5 && bun db:up && sleep 10 && temp=$(mktemp) && timeout -s KILL 20 bun dot:start | tee $temp; grep -i admin $temp > admin.log && rm $temp && echo '\nAdmin password info saved to root/admin.log'"
+    "admin:pass": "bun db:del && sleep 5 && bun db:up && sleep 10 && temp=$(mktemp) && timeout -s KILL 40 bun dot:start | tee $temp; grep -i admin $temp > admin.log && rm $temp && echo '\nAdmin password info saved to root/admin.log'"
   }
 }


### PR DESCRIPTION
Installs EF in dev container 

Increased timeout (20->40) in admin:pass script 🙏


To check: rebuild container and e.g. inside backend/ResearchCruiseApp run dotnet ef migrations list

If **'bin\Debug'** was created -> rm -rf 'bin\Debug' and try ef again

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Entity Framework Core CLI tool (`dotnet-ef`) to the dev container for managing database migrations, and increases the timeout in the `admin:pass` script to accommodate longer backend startup times.

- Installs `dotnet-ef` v10.0.3 as a global tool in the dev container
- Increases timeout from 20s to 40s in `admin:pass` script for more reliable admin password extraction

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Changes are straightforward infrastructure improvements: adding a widely-used CLI tool and adjusting a timeout value. No logic changes or potential runtime issues.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .devcontainer/Dockerfile | Added dotnet-ef CLI tool v10.0.3 installation to match .NET 10.0 SDK and project dependencies |
| package.json | Doubled timeout in admin:pass script from 20s to 40s to allow sufficient startup time |

</details>


</details>


<sub>Last reviewed commit: 6d01328</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->