### PR TITLE
chore: update copyright year to 2026 and add new contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Michał Tarnacki, Mateusz Kowalczyk, Maksymilian Panicz, Mateusz Nowak, Stanisław Nieradko, Krzysztof Nasuta, Paweł Pstrągowski, Bartłomiej Krawisz, Filip Dawidowski
+Copyright (c) 2026 Michał Tarnacki, Mateusz Kowalczyk, Maksymilian Panicz, Mateusz Nowak, Stanisław Nieradko, Krzysztof Nasuta, Paweł Pstrągowski, Bartłomiej Krawisz, Filip Dawidowski, Wojciech Siwiec, Filip Pudlak, Paweł Narwojsz, Bartosz Łyskanowski
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### TL;DR

Updated the LICENSE file to extend the copyright year to 2026 and added new contributors.

### What changed?

- Changed the copyright year from 2025 to 2026
- Added four new contributors to the copyright notice:
  - Wojciech Siwiec
  - Filip Pudlak
  - Paweł Narwojsz
  - Bartosz Łyskanowski

### How to test?

Verify that the LICENSE file displays the updated year (2026) and includes all contributors' names correctly.

### Why make this change?

To ensure the LICENSE file accurately reflects the current year of copyright protection and acknowledges all contributors to the project.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the LICENSE file to reflect the current year (2026) and acknowledges four new contributors to the project.

- Updated copyright year from 2025 to 2026
- Added Wojciech Siwiec, Filip Pudlak, Paweł Narwojsz, and Bartosz Łyskanowski to the copyright notice

This is a standard administrative update with no code or functionality changes.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with no risk
- This is a simple administrative change to the LICENSE file that only updates the copyright year and adds new contributors. No code, configuration, or functionality is affected.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| LICENSE | Updated copyright year to 2026 and added four new contributors to the copyright notice |

</details>


</details>


<sub>Last reviewed commit: 6bb6cab</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->