### PR TITLE
fix: prevent throwing InvalidOperationException when ids list is empty

### DIFF
--- a/backend/ResearchCruiseApp/Infrastructure/Persistence/Repositories/CruiseApplicationsRepository.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Persistence/Repositories/CruiseApplicationsRepository.cs
@@ -144,6 +144,9 @@ internal class CruiseApplicationsRepository
         CancellationToken cancellationToken
     )
     {
+        if (ids.Count == 0)
+            return Task.FromResult(new List<CruiseApplication>());
+
         return DbContext
             .CruiseApplications.Where(cruiseApplication => ids.Contains(cruiseApplication.Id))
             .ToListAsync(cancellationToken);

--- a/backend/ResearchCruiseApp/Infrastructure/Persistence/Repositories/CruisesRepository.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Persistence/Repositories/CruisesRepository.cs
@@ -86,6 +86,9 @@ internal class CruisesRepository : Repository<Cruise>, ICruisesRepository
         CancellationToken cancellationToken
     )
     {
+        if (ids.Count == 0)
+            return Task.FromResult(new List<Cruise>());
+
         return DbContext
             .Cruises.IncludeCruiseApplications()
             .Where(cruise =>


### PR DESCRIPTION
closes #313 

This PR solves problem that it was not possible to create a new ship blockade. 

The problem occurred during this call:
```cs
var affectedCruises = await cruisesRepository.GetByCruiseApplicationsIds(
            request.CruiseFormDto.CruiseApplicationsIds,
            cancellationToken
);
```
An InvalidOperationException was thrown when CruiseApplicationsIds was empty list (which is always the case for blockades). This issue appeared after updating to EF Core 10, which no longer supports empty collections as inline query roots in LINQ queries.

```cs
// This threw the exception in EF Core 10 when ids was empty
.Where(cruise =>
                ids.Any(id =>
                    cruise
                        .CruiseApplications.Select(cruiseApplication => cruiseApplication.Id)
                        .Contains(id)
                )
            )
```

To fix the problem, I added an early return condition checking whether the ids list is empty before querying the DbContext

Linked issue: [EF Core 10: InvalidOperationException...](https://github.com/dotnet/efcore/issues/37216)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an `InvalidOperationException` introduced by EF Core 10, which no longer supports empty collections as inline LINQ query roots. The root-cause method was `CruisesRepository.GetByCruiseApplicationsIds`, where an `ids.Any(...)` clause against an empty list caused the crash every time a ship blockade (which always starts with no cruise application IDs) was created. The same guard is added to `CruiseApplicationsRepository.GetAllByIds` as a defensive measure.

**Key changes:**
- `CruisesRepository.GetByCruiseApplicationsIds`: returns `Task.FromResult(new List<Cruise>())` immediately when `ids` is empty, bypassing the problematic LINQ query.
- `CruiseApplicationsRepository.GetAllByIds`: same early-return guard added for consistency and future safety.
- Both fixes are minimal, correctly scoped, and semantically sound — querying for items matching IDs from an empty set should always yield an empty result.
- `Task.FromResult` is the correct pattern here since neither method is declared `async`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it introduces a well-scoped, semantically correct guard with no side-effects on existing behaviour.
- The fix is minimal (3 lines per method), logically correct (empty IDs → empty result), consistent with the rest of the codebase style, and directly addresses the reproduction case described in the linked EF Core issue. No new code paths are introduced for the non-empty case, so there is no regression risk.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/ResearchCruiseApp/Infrastructure/Persistence/Repositories/CruisesRepository.cs | Adds an early-return guard in `GetByCruiseApplicationsIds` to return an empty list when `ids` is empty, fixing the EF Core 10 `InvalidOperationException` for the blockade creation flow. |
| backend/ResearchCruiseApp/Infrastructure/Persistence/Repositories/CruiseApplicationsRepository.cs | Adds the same early-return guard in `GetAllByIds` as a defensive improvement; the `ids.Contains(...)` pattern may not have been broken in EF Core 10, but the guard is a correct and harmless optimisation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Call GetByCruiseApplicationsIds / GetAllByIds] --> B{ids.Count == 0?}
    B -- Yes --> C[return Task.FromResult empty list\nno DB query]
    B -- No --> D[Build LINQ query against DbContext]
    D --> E[EF Core translates to SQL\nWHERE ... IN ids / ANY ids]
    E --> F[ToListAsync returns results]
    C --> G[Caller receives empty list]
    F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent throwing InvalidOperationEx..."](https://github.com/vv01t3k/researchcruiseapp/commit/e8ada635f64ef066dc6e10873ca5d71e6d795e2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26036385)</sub>

<!-- /greptile_comment -->