### PR TITLE
Nonempty optimal period slider

### DIFF
--- a/frontend/src/modules/cruise-applications/components/common/CruiseApplicationPeriodInput.tsx
+++ b/frontend/src/modules/cruise-applications/components/common/CruiseApplicationPeriodInput.tsx
@@ -37,7 +37,7 @@ function clampToBounds(values: [number, number], min: number, max: number): [num
   const clampedEnd = Math.max(min, Math.min(values[1], max));
 
   if (clampedStart < clampedEnd) return [clampedStart, clampedEnd];
-  if (max <= min) return [min, max];
+  if (max <= min) return [min, max === min ? min + 1 : max];
   return clampedStart >= max ? [max - 1, max] : [clampedStart, Math.min(clampedStart + 1, max)];
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in `CruiseApplicationPeriodInput` where the optimal-period slider could end up in a degenerate (zero-length) state, with both thumbs at the same position. The fix involves two coordinated changes:

- **`clampToBounds`** now detects when both clamped values collapse to `max` (e.g. both initial values exceed the upper bound) and returns `[max - 1, max]` instead of the previous `[max, max]`.
- **`useEffect`** receives a new early-return guard (`if (clamped[0] === clamped[1]) return;`) to prevent ever calling `onChange` with an equal start/end pair, which would be an invalid `CruisePeriodType`.

The logic is correct for the common cases. One remaining edge case: when `maxValues` constrains both bounds to the same fortnight (`max === min`), `clampToBounds` still returns `[min, min]`; the guard in `useEffect` silently swallows the `onChange` call, but the slider is still rendered with overlapping thumbs and a zero-width indicator. If the form value starts empty in this scenario it can never be initialised.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the main bug is correctly fixed; only a minor edge case with degenerate bounds remains.
- The primary regression (slider producing a zero-length period when both values clamp to `max`) is properly addressed. The added guard in `useEffect` prevents invalid state from propagating to the form. The only remaining gap is the `max === min` degenerate-bounds scenario which silently skips `onChange` and could leave the form uninitialised, but this requires specially crafted `maxValues` input and is unlikely to affect normal usage.
- No files require special attention beyond the one changed file.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/modules/cruise-applications/components/common/CruiseApplicationPeriodInput.tsx | Fixes the main bug where both slider thumbs could clamp to `max` and produce an equal (zero-length) period; adds a `useEffect` guard to prevent propagating the degenerate state. One edge case remains: when `max === min`, `clampToBounds` returns `[min, min]`, the guard silently swallows the `onChange` call, and the form value can never be initialised if it starts invalid. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["clampToBounds(values, min, max)"] --> B["Clamp both ends to min/max bounds"]
    B --> C{clampedStart < clampedEnd?}
    C -- Yes --> D["return clampedStart, clampedEnd"]
    C -- No --> E{max <= min?}
    E -- Yes --> F["return min, max — may equal min,min when max==min"]
    E -- No --> G{clampedStart >= max?}
    G -- Yes --> H["return max-1, max  FIX"]
    G -- No --> I["return clampedStart, clampedStart+1"]

    J["useEffect: bounds changed"] --> K["clamped = sliderValues"]
    K --> L{valueChanged?}
    L -- No --> M["skip onChange"]
    L -- Yes --> N{clamped start == clamped end?}
    N -- Yes --> O["return early, skip onChange  GUARD"]
    N -- No --> P["call onChange with clamped period"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/modules/cruise-applications/components/common/CruiseApplicationPeriodInput.tsx
Line: 40

Comment:
**Degenerate bounds still yield `[min, min]`**

When `max === min`, this branch returns `[min, max]` which resolves to `[min, min]` — a zero-length range. The `useEffect` guard at line 74 correctly prevents propagating this via `onChange`, but `sliderValues` will still be `[min, min]`, causing the slider to render with overlapping thumbs and a zero-width indicator.

More importantly, if the form's `value` is initially empty/invalid AND the bounds are degenerate (`max === min`), `valueChanged` will be `true` but the early-return guard will prevent `onChange` from ever firing — meaning the form value can never be initialised to a valid value in this scenario. This is a silent failure mode.

If a non-empty period cannot be expressed within the given bounds, consider surfacing an error or falling back to the component's disabled state rather than silently skipping the `onChange` call.

```suggestion
  if (max <= min) return [min, max === min ? min + 1 : max];
```
Note: this suggestion only works if the Slider's hardcoded `max={24}` allows it; alternatively, disable/hide the slider when `maxValues` is degenerate.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(formA): slider optimal period need t..."](https://github.com/vv01t3k/researchcruiseapp/commit/0e524ae273528a6c6e3efb6c2e7c6c031aaba0b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26043806)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->