### PR TITLE
Fix/ensure day buttons are clickable

### DIFF
--- a/frontend/tests/utils/form-filling-utils.ts
+++ b/frontend/tests/utils/form-filling-utils.ts
@@ -47,20 +47,31 @@ export class FormDropdown<TErrors extends Record<string, Locator> = Record<strin
       const menu = this.page.getByRole('menu').last();
       const dayButtons = menu.getByRole('button', { name: itemText, exact: true });
       const dayButtonsCount = await dayButtons.count();
-      let selected = false;
 
-      for (let i = 0; i < dayButtonsCount; i++) {
-        const dayButton = dayButtons.nth(i);
-        if (await dayButton.isEnabled()) {
-          await dayButton.click();
-          selected = true;
-          break;
+      if (dayButtonsCount === 0) {
+        throw new Error(`Could not find datetime-picker day button with text: ${itemText}`);
+      }
+
+      let indexToClick = 0;
+
+      if (dayButtonsCount === 2) {
+        const dayNumber = parseInt(itemText, 10);
+        if (dayNumber > 15) {
+          // e.g. 26. First "26" is prev month day, second is current month day
+          indexToClick = 1;
+        } else {
+          // e.g. 2. First "2" is current month day, second is next month day
+          indexToClick = 0;
         }
       }
 
-      if (!selected) {
+      const dayButton = dayButtons.nth(indexToClick);
+      if (await dayButton.isEnabled()) {
+        await dayButton.click();
+      } else {
         throw new Error(`Could not find enabled datetime-picker day button: ${itemText}`);
       }
+
       // Click on main content area to close the datetime picker (triggers useOutsideClickDetection)
       await this.page.getByTestId('main-content').click({ position: { x: 1, y: 1 } });
       await expect(menu).toBeHidden();


### PR DESCRIPTION
Problem:
The datetime picker shows days from the previous/next month (e.g., two "25" buttons). Tests were clicking the "gray" one from the wrong month, which didn't trigger the date selection, leaving the calendar open and failing the toBeHidden() check.
<img width="1046" height="633" alt="obraz" src="https://github.com/user-attachments/assets/7b85a649-848a-46c1-86f4-d242ee8110af" />


Fix:
Updated selectOption in form-filling-utils.ts to click only buttons (in datetime-picker) with .text-default class(buttons from previous/next month does not have that class)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two related but distinct bugs. The primary fix updates the Playwright `selectOption` helper in `form-filling-utils.ts` so that the `datetime-picker` variant only clicks day buttons belonging to the **currently displayed month**. Previously, when the calendar showed overflow days from the previous or next month (e.g. two buttons both labelled "25"), the loop would click the first enabled one regardless of which month it belonged to; that button did not trigger a date selection, leaving the picker open and causing the `toBeHidden()` assertion to fail. The fix uses the presence of the `text-default` CSS class as a discriminator for current-month days.

The secondary fix refactors `clampToBounds` in `CruiseApplicationPeriodInput.tsx` to correctly handle the edge case where both slider thumbs reach the upper bound (`max`), which previously collapsed the interval to `[max, max]`; a complementary guard in the `useEffect` prevents calling `onChange` with an equal-valued pair.

- **`form-filling-utils.ts`**: Core logic is correct; the `text-default` selector is implicitly coupled to the component library's class naming — worth a comment for future maintainers.
- **`CruiseApplicationPeriodInput.tsx`**: The `max <= min` branch in `clampToBounds` conflates `max === min` (returns a valid `[min, min+1]`) with `max < min` (returns an inverted `[min, max]` tuple). The `max < min` path is unreachable in practice (guaranteed by `parsePeriod`), but could theoretically cause a re-render loop if it were ever hit.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — both fixes are sound and address real bugs; remaining concerns are theoretical edge cases and a documentation gap, not production risks.
- The datetime-picker test fix is well-motivated and correct. The `clampToBounds` refactor resolves a real slider collision bug. The only concerns are a fragile CSS class selector in the test utility (P2, not a runtime bug) and an unreachable `max < min` code path that returns an inverted tuple. Neither concern affects normal production usage.
- No files require special attention; the `max < min` path in `CruiseApplicationPeriodInput.tsx` is worth a clarifying comment but is not reachable with valid inputs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/tests/utils/form-filling-utils.ts | Adds a `text-default` CSS class check to skip overflow (previous/next month) day buttons in the datetime-picker variant of `selectOption`, fixing tests that were clicking the wrong day button and leaving the calendar open. The fix is correct; the only concern is the selector is implicitly coupled to the component library's class name. |
| frontend/src/modules/cruise-applications/components/common/CruiseApplicationPeriodInput.tsx | Refactors `clampToBounds` to correctly handle the edge case where both slider thumbs reach `max` (previously returned `[max, max]`); adds a guard in the effect to avoid calling `onChange` when the clamped interval collapses to a single point. The `max < min` sub-case in the new branch returns an inverted tuple, which is only a theoretical concern since `parsePeriod` prevents it in practice. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[selectOption called with day text] --> B[Click dropdown to open datetime-picker]
    B --> C[Locate all buttons matching day number]
    C --> D{For each button}
    D --> E{isEnabled?}
    E -- No --> D
    E -- Yes --> F{has 'text-default' class?}
    F -- No: overflow day from prev/next month --> D
    F -- Yes: current month day --> G[Click button]
    G --> H[selected = true, break]
    H --> I[Click main-content to close picker]
    I --> J[Assert menu is hidden]
    D -- no more buttons --> K{selected?}
    K -- No --> L[Throw: Could not find enabled datetime-picker day button]
    K -- Yes --> J
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/modules/cruise-applications/components/common/CruiseApplicationPeriodInput.tsx
Line: 40

Comment:
**Inverted tuple returned when `max < min`**

The `max <= min` branch handles two distinct cases with one return expression:

- When `max === min`: returns `[min, min + 1]` — reasonable, forces a non-zero span.
- When `max < min` (invalid input): returns `[min, max]` where `min > max` — an inverted pair.

If `max < min` were somehow reached, the returned `[min, max]` would get passed to `onChange`, `parsePeriod` would swap the values to `[max, min]`, and `clampToBounds` would be called again with still-inverted bounds, potentially looping. In practice `parsePeriod` guarantees `minBound ≤ maxBound`, so this path shouldn't be hit — but the branch silently produces an invalid result instead of short-circuiting or asserting. Consider separating the two sub-cases for clarity and safety:

```suggestion
  if (max === min) return [min, min + 1];
  if (max < min) return [min, max]; // shouldn't happen; caller guarantees min ≤ max
```
or simply keep the guard scoped to only `max === min`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/tests/utils/form-filling-utils.ts
Line: 56

Comment:
**Fragile CSS class name coupling**

The fix keys off the string `'text-default'` appearing in the button's `class` attribute to distinguish current-month days from overflow days. This works today, but if the underlying date-picker component or its Tailwind configuration ever renames or removes this class, the condition will silently evaluate to `undefined` (falsy) for **every** button, no day will be selected, and the test will throw the generic `Could not find enabled datetime-picker day button` error rather than a clear signal that the selector has drifted.

Consider documenting the assumption with a comment that names the component/library producing the class, or adding a fallback assertion like:

```typescript
// 'text-default' is set by <DatePickerComponent> on days belonging to the displayed month.
// If this selector breaks after a library upgrade, update it to match the new class name.
const isCurrentMonthDay = (await dayButton.getAttribute('class'))?.includes('text-default');
```

This doesn't change the runtime behaviour but makes the fragile coupling explicit and easier to diagnose later.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): select only current month da..."](https://github.com/vv01t3k/researchcruiseapp/commit/aef233bd93744ed4637ffe7cb3f4aece61923088) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26352041)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->