### PR TITLE
Fix(tests)/ensure day buttons are clickable

### DIFF
--- a/frontend/tests/utils/form-filling-utils.ts
+++ b/frontend/tests/utils/form-filling-utils.ts
@@ -47,20 +47,33 @@ export class FormDropdown<TErrors extends Record<string, Locator> = Record<strin
       const menu = this.page.getByRole('menu').last();
       const dayButtons = menu.getByRole('button', { name: itemText, exact: true });
       const dayButtonsCount = await dayButtons.count();
-      let selected = false;
 
-      for (let i = 0; i < dayButtonsCount; i++) {
-        const dayButton = dayButtons.nth(i);
-        if (await dayButton.isEnabled()) {
-          await dayButton.click();
-          selected = true;
-          break;
-        }
+      if (dayButtonsCount === 0) {
+        throw new Error(`Could not find datetime-picker day button with text: ${itemText}`);
       }
 
-      if (!selected) {
+      let indexToClick = 0;
+
+      if (dayButtonsCount === 2) {
+        const dayNumber = parseInt(itemText, 10);
+        if (dayNumber > 15) {
+          // e.g. 26. First "26" is prev month day, second is current month day
+          indexToClick = 1;
+        } else {
+          // e.g. 2. First "2" is current month day, second is next month day
+          indexToClick = 0;
+        }
+      } else if (dayButtonsCount > 2) {
+        throw new Error(`Unexpected number of datetime-picker day buttons (${dayButtonsCount}) for day: ${itemText}`);
+      }
+
+      const dayButton = dayButtons.nth(indexToClick);
+      if (await dayButton.isEnabled()) {
+        await dayButton.click();
+      } else {
         throw new Error(`Could not find enabled datetime-picker day button: ${itemText}`);
       }
+
       // Click on main content area to close the datetime picker (triggers useOutsideClickDetection)
       await this.page.getByTestId('main-content').click({ position: { x: 1, y: 1 } });
       await expect(menu).toBeHidden();


### PR DESCRIPTION
Problem:
The datetime picker shows days from the previous/next month (e.g., two "25" buttons). Tests were clicking the "gray" one from the wrong month, which didn't trigger the date selection, leaving the calendar open and failing the toBeHidden() check.
<img width="1046" height="633" alt="obraz" src="https://github.com/user-attachments/assets/7b85a649-848a-46c1-86f4-d242ee8110af" />


Fix:
Updated selectOption in form-filling-utils.ts to click only buttons (in datetime-picker) from current month. If there are two buttons with the same day number (from adjacent months), the test now calculates and clicks the correct one belonging to the current month

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a flaky E2E test that occurred when a datetime picker displayed identically-numbered day buttons from both the current month and an adjacent month. The fix replaces the previous "click first enabled button" loop with a deterministic index heuristic: if the day number is > 15 the button at index 1 is clicked (the current-month button, preceded by the previous month's overflow day), and if ≤ 15 the button at index 0 is clicked (the current-month button, before the next month's overflow day appears).\n\n**Key changes:**\n- Removed the `for` loop that clicked the first enabled button without considering month context.\n- Added explicit `dayButtonsCount === 0` guard to fail fast with a descriptive error.\n- Added index-based heuristic (`dayNumber > 15 → index 1`, else `index 0`) scoped only to the `dayButtonsCount === 2` case.\n- Added an early-exit error if the selected button is disabled, replacing the old silent no-op path.\n\n**One minor issue:** When `dayButtonsCount > 2`, the code silently falls back to `indexToClick = 0`, which would click the wrong button for days > 15. A guard is recommended.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the heuristic is logically sound for all realistic calendar layouts and directly addresses the described flakiness.

The > 15 threshold correctly maps to previous-month overflow (high numbers like 25-31) vs next-month overflow (low numbers like 1-6), covering every real-world calendar grid. The only open concern is the unhandled dayButtonsCount > 2 case, but this is practically unreachable and the impact is limited to tests, not production code.

Only frontend/tests/utils/form-filling-utils.ts changed; the dayButtonsCount > 2 silent fallback is the sole item worth addressing before merge.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/tests/utils/form-filling-utils.ts | Replaced loop-based day-button selection with an index heuristic (day > 15 → index 1, otherwise index 0) to always click the current-month button; edge case where dayButtonsCount > 2 silently falls back to index 0. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/tests/utils/form-filling-utils.ts
Line: 57-66

Comment:
**Unhandled case when `dayButtonsCount > 2`**

When `dayButtonsCount > 2`, the `if (dayButtonsCount === 2)` block is skipped and `indexToClick` stays at `0`. For a day number > 15 this would end up clicking the previous-month button — the same bug the PR set out to fix.

In practice a standard calendar grid should never render the same day number more than twice, but if the DOM ever ends up in that state (e.g. multiple menus stacking up) the failure mode is silent and confusing.

Consider guarding with a throw:

```suggestion
      if (dayButtonsCount === 2) {
        const dayNumber = parseInt(itemText, 10);
        if (dayNumber > 15) {
          // e.g. 26. First "26" is prev month day, second is current month day
          indexToClick = 1;
        } else {
          // e.g. 2. First "2" is current month day, second is next month day
          indexToClick = 0;
        }
      } else if (dayButtonsCount > 2) {
        throw new Error(
          `Unexpected number of datetime-picker day buttons (${dayButtonsCount}) for day: ${itemText}`
        );
      }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): select only current month da..."](https://github.com/vv01t3k/researchcruiseapp/commit/a941127d6b51fa0c9bf5f6400ae611f18e8e7ed8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26420098)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->