### PR TITLE
fix: enchance session automated tests

### DIFF
--- a/frontend/tests/session.spec.ts
+++ b/frontend/tests/session.spec.ts
@@ -73,6 +73,7 @@ async function seedAuthAndNavigate(page: Page, authPayload: ReturnType<typeof ge
 
 test.describe('session expiration and refresh', () => {
   test('warning modal appears ~1 minute before session expires', async ({ page }) => {
+    await page.clock.install({ time: Date.now() });
     await setupAuthMocks(page, {
       refreshResponse: { status: 200, body: getRefreshResponsePayloadMs(24 * 60 * 60 * 1000) },
     });
@@ -81,9 +82,10 @@ test.describe('session expiration and refresh', () => {
     await seedAuthAndNavigate(page, getAuthDetailsPayloadMs(63_000));
 
     const warningTitle = page.getByText('Sesja wygasa');
-    const warningMessage = page.getByText(/Twoja sesja wygaśnie za/);
-    await expect(warningTitle).toBeVisible({ timeout: 10_000 });
-    await expect(warningMessage).toBeVisible({ timeout: 10_000 });
+
+    await page.clock.runFor(3_500);
+
+    await expect(warningTitle).toBeVisible();
   });
 
   test('session expiry shows warning and redirects to login', async ({ page }) => {
@@ -164,6 +166,7 @@ test.describe('session expiration and refresh', () => {
   });
 
   test('manual refresh button calls refresh endpoint and extends session', async ({ page }) => {
+    await page.clock.install({ time: Date.now() });
     const extendedAuth = getRefreshResponsePayloadMs(24 * 60 * 60 * 1000);
     const initialSessionMs = 12_000;
     await setupAuthMocks(page, {
@@ -201,6 +204,8 @@ test.describe('session expiration and refresh', () => {
     const body = refreshResponse.request().postDataJSON();
     expect(body).toHaveProperty('accessToken');
     expect(body).toHaveProperty('refreshToken');
+
+    await page.clock.runFor(1_000);
 
     const afterRefreshAuthDetails = await page.evaluate(() => {
       const raw = window.localStorage.getItem('authDetails');


### PR DESCRIPTION
corrected the test logic and made them more repetitive

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the session Playwright test suite to use `page.clock.install` throughout for deterministic, non-flaky time control. It removes the previously problematic \"successful refresh extends session and prevents redirect\" test, adds a new \"expired access token on `/usermanagement` reload keeps route via refresh token\" test with correct `waitForResponse`-before-`reload` ordering, and upgrades the manual-refresh test to also validate localStorage state changes.

**Key changes:**
- `page.clock.install({ time: Date.now() })` added to three tests to prevent real-timer flakiness.
- New helper `getAuthDetailsPayloadWithExpirations` enables independent control of access-token and refresh-token offsets.
- The new \"expired access token\" test correctly seeds a **valid** access token during initial navigation, then surgically expires it in `localStorage` before reload.
- Manual-refresh test now verifies `refreshTokenExpirationDate` is updated in `localStorage` after a successful refresh.

**One finding:** The test title and inline comment reference a 60-second warning threshold; the actual `WARNING_THRESHOLD_MS` in `SessionExpirationWarning.tsx` is 5 minutes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only finding is a misleading comment and test title; no production code is changed.

All changes are confined to a single test file. The structural improvements are sound. The sole P2 finding is a stale inline comment and test name referencing a 60 s threshold the component never had (actual: 5 min); zero runtime impact.

frontend/tests/session.spec.ts — minor comment/title inaccuracy regarding the warning threshold

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/tests/session.spec.ts | Session test suite refactored to use `page.clock.install` for deterministic time control; adds new expired-access-token-on-reload test; fixes `waitForResponse` ordering in manual-refresh test; one P2 issue: warning threshold comment and test title assume 60 s but actual `WARNING_THRESHOLD_MS` is 5 minutes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Test
    participant B as Browser (fake clock)
    participant App as React App
    participant API as Mock API

    Note over T,API: session expiry shows warning and redirects to login
    T->>B: clock.install({ time: now })
    T->>API: route /account/refresh → hang
    T->>B: seedAuthAndNavigate (10 s token)
    B->>App: mount — shouldWarn = (10 s ≤ 5 min) → modal opens
    T->>B: expect(warningTitle).toBeVisible ✓
    T->>B: clock.runFor(10_500)
    B->>App: setInterval checkExpiration fires at +10 s → signOut()
    B-->>T: URL = /login ✓

    Note over T,API: expired access token on reload keeps route via refresh token
    T->>API: route /account/refresh → 200 extendedAuth
    T->>B: seedAuthAndNavigate (access 60 s, refresh 24 h)
    T->>B: evaluate() — overwrite accessTokenExpiry to -5 s
    T->>B: waitForResponse(/account/refresh)
    T->>B: page.reload()
    B->>App: mount — initRefreshRef: accessTokenExpiry ≤ now → refresh
    App->>API: POST /account/refresh
    API-->>App: 200 extendedAuth
    App->>App: update localStorage
    B-->>T: refreshPromise resolves ✓
    T->>B: expect(page).toHaveURL('/usermanagement') ✓
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/tests/session.spec.ts
Line: 75-88

Comment:
**Wrong warning threshold in test name and inline comment**

`SessionExpirationWarning.tsx` sets `WARNING_THRESHOLD_MS = 5 * 60 * 1000` (5 minutes), not 60 seconds. As a result:

- The test name "warning modal appears **~1 minute** before session expires" is inaccurate — the modal actually opens ~**5 minutes** before expiry.
- The inline comment `// 63s expiration: warning fires at 63000 - 60000 = 3000ms` is wrong. With a 5-minute threshold, a 63 s session is already inside the warning window on mount, so `shouldWarn` is `true` immediately and `clock.runFor(3_500)` on line 86 is redundant.

The `toBeVisible()` assertion passes because the modal opens on mount, not because the clock was advanced 3.5 s. The unnecessary `runFor` call could mislead future contributors into thinking there is a 3-second warm-up before the modal appears.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: get rid of race condition"](https://github.com/vv01t3k/researchcruiseapp/commit/a8054b077fb9a52519b492497177c274092ba2bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26659957)</sub>

<!-- /greptile_comment -->