### PR TITLE
Calendar drag and drop

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@grafana/faro-web-sdk": "^2.2.3",
     "@grafana/faro-web-tracing": "^2.2.3",
     "@tanstack/react-form": "1.28.0",

--- a/frontend/src/modules/core/components/calendar/AppCalendar.tsx
+++ b/frontend/src/modules/core/components/calendar/AppCalendar.tsx
@@ -109,6 +109,7 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
   React.useEffect(() => {
     const viewport = window.visualViewport;
     if (!viewport) return;
+    updateTileWidth();
     const handleViewportResize = () => updateTileWidth();
     viewport.addEventListener('resize', handleViewportResize);
     return () => {

--- a/frontend/src/modules/core/components/calendar/AppCalendar.tsx
+++ b/frontend/src/modules/core/components/calendar/AppCalendar.tsx
@@ -70,7 +70,6 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
   const updateTileWidth = React.useCallback(() => {
     const calendarElement = calendarRef.current;
     if (!calendarElement) {
-      console.log('Calendar element not found');
       return;
     }
 
@@ -333,11 +332,10 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
           nextEnd,
         })
       );
-    } catch (error) {
+    } catch {
       setActiveDragEventId(undefined);
       setDropPreviewDays([]);
       setPendingDrop(undefined);
-      throw error;
     }
   }
 
@@ -418,20 +416,6 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
   const overlayScrollOffsetY = typeof window === 'undefined' ? 0 : window.scrollY;
   const overlayDrawTop =
     DRAG_CURSOR_Y_NUDGE - activeDragPointerOffsetY - overlayAnchor.row * dragWeekRowStep + overlayScrollOffsetY;
-
-  React.useEffect(() => {
-    if (!activeDragOverlay || overlaySegments.length === 0) {
-      return;
-    }
-  }, [
-    activeDragOverlay,
-    overlaySegments.length,
-    overlayDrawLeft,
-    overlayDrawTop,
-    overlayScrollOffsetY,
-    overlayAnchor.row,
-    overlayAnchor.column,
-  ]);
 
   const defaultButtons = [
     <AppButton

--- a/frontend/src/modules/core/components/calendar/AppCalendar.tsx
+++ b/frontend/src/modules/core/components/calendar/AppCalendar.tsx
@@ -19,6 +19,7 @@ import { AppButton } from '@/core/components/AppButton';
 import { AppCalendarTile } from '@/core/components/calendar/AppCalendarTile';
 import { AppMonthPickerPopover } from '@/core/components/inputs/dates/AppMonthPickerPopover';
 import { dateToUtcDay, getDaysInMonth, months, weekDays } from '@/core/lib/calendarUtils';
+import type { CalendarEvent, CalendarEventWithRow, CalendarEventDropPayload } from './calendarTypes';
 
 function assignEventsToRows(events: CalendarEvent[]): CalendarEventWithRow[] {
   const eventsWithRows = events.map((event) => ({ ...event, row: 0 }));
@@ -63,18 +64,27 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
   const [dragBlockRowGap, setDragBlockRowGap] = React.useState(4);
   const [dragWeekRowStep, setDragWeekRowStep] = React.useState(120);
 
-  function updateTileWidth() {
-    const calendarWidth = calendarRef.current?.offsetWidth ?? 700;
-    // oxlint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
-    setTileWidth(calendarWidth / 7);
+  const updateTileWidth = React.useCallback(() => {
+    const calendarElement = calendarRef.current;
+    if (!calendarElement) {
+      console.log('Calendar element not found');
+      return;
+    }
 
-    const eventBlock = calendarRef.current?.querySelector<HTMLElement>('[data-calendar-event-block]');
+    const dayTiles = calendarElement.querySelectorAll<HTMLElement>('[data-calendar-day-tile]');
+    const calendarWidth = calendarElement.getBoundingClientRect().width;
+    if (Number.isFinite(calendarWidth) && calendarWidth > 0) {
+      // oxlint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+      setTileWidth(calendarWidth / 7);
+    }
+
+    const eventBlock = calendarElement.querySelector<HTMLElement>('[data-calendar-event-block]');
     if (eventBlock) {
       // oxlint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
       setDragBlockHeight(eventBlock.getBoundingClientRect().height);
     }
 
-    const eventRows = calendarRef.current?.querySelector<HTMLElement>('[data-calendar-event-rows]');
+    const eventRows = calendarElement.querySelector<HTMLElement>('[data-calendar-event-rows]');
     if (eventRows) {
       const rowGap = Number.parseFloat(window.getComputedStyle(eventRows).rowGap || '0');
       if (Number.isFinite(rowGap)) {
@@ -83,8 +93,7 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
       }
     }
 
-    const dayTiles = calendarRef.current?.querySelectorAll<HTMLElement>('[data-calendar-day-tile]');
-    if (dayTiles && dayTiles.length > 7) {
+    if (dayTiles.length > 7) {
       const firstRowTop = dayTiles[0].getBoundingClientRect().top;
       const secondRowTop = dayTiles[7].getBoundingClientRect().top;
       const weekStep = secondRowTop - firstRowTop;
@@ -93,22 +102,32 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
         setDragWeekRowStep(weekStep);
       }
     }
+  }, []);
+
+  React.useEffect(() => {
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+    const handleViewportResize = () => updateTileWidth();
+    viewport.addEventListener('resize', handleViewportResize);
+    return () => {
+      viewport.removeEventListener('resize', handleViewportResize);
+    };
+  }, [updateTileWidth]);
+
+  function getInitialTopFromActivatorEvent(activatorEvent: Event): number | undefined {
+    const target = activatorEvent.target;
+    if (!(target instanceof Element)) {
+      return undefined;
+    }
+
+    const eventBlock = target.closest('[data-calendar-event-block]');
+    const element = eventBlock ?? target;
+    return element.getBoundingClientRect().top;
   }
 
-  React.useEffect(() => {
-    updateTileWidth();
-  }, []);
-
-  React.useEffect(() => {
-    window.addEventListener('resize', updateTileWidth);
-    return () => {
-      window.removeEventListener('resize', updateTileWidth);
-    };
-  }, []);
-
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 8 } })
+    useSensor(PointerSensor, { activationConstraint: { delay: 0, tolerance: 0 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 0, tolerance: 0 } })
   );
 
   function getDayNumberFromDropId(dropId: string): number | undefined {
@@ -209,8 +228,8 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
 
     const startDayUtc = dateToUtcDay(draggedEvent.start);
     const anchorOffset = Math.floor((sourceDayUtc - startDayUtc) / DAY_MS);
-    const initialTop = event.active.rect.current.initial?.top;
     const activatorEvent = event.activatorEvent;
+    const initialTop = event.active.rect.current.initial?.top ?? getInitialTopFromActivatorEvent(activatorEvent);
     let pointerY: number | undefined;
     if ('clientY' in activatorEvent && typeof activatorEvent.clientY === 'number') {
       pointerY = activatorEvent.clientY;
@@ -312,14 +331,76 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
   }
 
   const eventsWithRows = React.useMemo(() => assignEventsToRows(events), [events]);
+  const displayedMonthDays = React.useMemo(() => getDaysInMonth(currentMonth), [currentMonth]);
+  const displayedStartDayUtc = displayedMonthDays.length > 0 ? dateToUtcDay(displayedMonthDays[0]) : undefined;
+  const displayedEndDayUtc =
+    displayedMonthDays.length > 0 ? dateToUtcDay(displayedMonthDays[displayedMonthDays.length - 1]) : undefined;
+
+  const overlayVisibleWindow = React.useMemo(() => {
+    if (
+      !activeDragOverlay ||
+      dropPreviewDays.length === 0 ||
+      displayedStartDayUtc === undefined ||
+      displayedEndDayUtc === undefined
+    ) {
+      return undefined;
+    }
+
+    const previewStartDayUtc = dropPreviewDays[0];
+    const previewEndDayUtc = previewStartDayUtc + (activeDragOverlay.spanDays - 1) * DAY_MS;
+    const visibleStartDayUtc = Math.max(previewStartDayUtc, displayedStartDayUtc);
+    const visibleEndDayUtc = Math.min(previewEndDayUtc, displayedEndDayUtc);
+
+    if (visibleEndDayUtc < visibleStartDayUtc) {
+      return undefined;
+    }
+
+    const hiddenLeadingDays = Math.floor((visibleStartDayUtc - previewStartDayUtc) / DAY_MS);
+    const visibleSpanDays = Math.floor((visibleEndDayUtc - visibleStartDayUtc) / DAY_MS) + 1;
+    return {
+      visibleStartDayUtc,
+      visibleSpanDays,
+      hiddenLeadingDays,
+    };
+  }, [DAY_MS, activeDragOverlay, displayedEndDayUtc, displayedStartDayUtc, dropPreviewDays]);
+
   const overlaySegments =
-    activeDragOverlay && dropPreviewDays.length > 0
-      ? buildWeeklyOverlaySegments(dropPreviewDays[0], activeDragOverlay.spanDays)
+    overlayVisibleWindow && overlayVisibleWindow.visibleSpanDays > 0
+      ? buildWeeklyOverlaySegments(overlayVisibleWindow.visibleStartDayUtc, overlayVisibleWindow.visibleSpanDays)
       : [];
+
+  const visibleAnchorOffset =
+    activeDragOverlay && overlayVisibleWindow
+      ? Math.max(
+          0,
+          Math.min(
+            overlayVisibleWindow.visibleSpanDays - 1,
+            activeDragOverlay.anchorOffset - overlayVisibleWindow.hiddenLeadingDays
+          )
+        )
+      : 0;
+
   const overlayAnchor =
-    activeDragOverlay && overlaySegments.length > 0
-      ? getOverlayAnchorPosition(overlaySegments, activeDragOverlay.anchorOffset)
-      : { row: 0, column: 0 };
+    overlaySegments.length > 0 ? getOverlayAnchorPosition(overlaySegments, visibleAnchorOffset) : { row: 0, column: 0 };
+
+  const overlayDrawLeft = -(overlayAnchor.column * tileWidth);
+  const overlayScrollOffsetY = typeof window === 'undefined' ? 0 : window.scrollY;
+  const overlayDrawTop =
+    DRAG_CURSOR_Y_NUDGE - activeDragPointerOffsetY - overlayAnchor.row * dragWeekRowStep + overlayScrollOffsetY;
+
+  React.useEffect(() => {
+    if (!activeDragOverlay || overlaySegments.length === 0) {
+      return;
+    }
+  }, [
+    activeDragOverlay,
+    overlaySegments.length,
+    overlayDrawLeft,
+    overlayDrawTop,
+    overlayScrollOffsetY,
+    overlayAnchor.row,
+    overlayAnchor.column,
+  ]);
 
   const defaultButtons = [
     <AppButton
@@ -349,7 +430,7 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
     currentMonth.year * 12 + currentMonth.month > previousMonth.year * 12 + previousMonth.month ? 'right' : 'left';
 
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <div ref={calendarRef} className="flex flex-col gap-4 p-4">
       <div className="flex w-full items-center justify-center">
         <AppButton variant="plain" onClick={() => handleMonthChange(-1)}>
           <ChevronLeftIcon className="h-8 w-8" />
@@ -385,13 +466,13 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
             onDragCancel={handleDragCancel}
             onDragEnd={handleDragEnd}
           >
-            <div ref={calendarRef} className="grid grid-cols-7 gap-1">
+            <div className="grid grid-cols-7 gap-1">
               {weekDays.map((day) => (
                 <div key={day} className="truncate text-center">
                   {day}
                 </div>
               ))}
-              {getDaysInMonth(currentMonth).map((date) => (
+              {displayedMonthDays.map((date) => (
                 <AppCalendarTile
                   date={date}
                   eventsWithRows={eventsWithRows}
@@ -406,12 +487,12 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
               ))}
             </div>
             <DragOverlay adjustScale={false}>
-              {activeDragOverlay ? (
+              {activeDragOverlay && overlaySegments.length > 0 ? (
                 <div
                   className="pointer-events-none"
                   style={{
-                    marginLeft: -(overlayAnchor.column * tileWidth),
-                    marginTop: DRAG_CURSOR_Y_NUDGE - activeDragPointerOffsetY - overlayAnchor.row * dragWeekRowStep,
+                    marginLeft: overlayDrawLeft,
+                    marginTop: overlayDrawTop,
                   }}
                 >
                   <div
@@ -440,23 +521,3 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
     </div>
   );
 }
-
-export type CalendarEvent = {
-  id?: string;
-  title: string;
-  start: Date;
-  end: Date;
-
-  link?: string;
-  color?: string;
-};
-
-export type CalendarEventWithRow = CalendarEvent & { row: number };
-
-export type CalendarEventDropPayload = {
-  event: CalendarEvent;
-  sourceDate: Date;
-  targetDate: Date;
-  nextStart: Date;
-  nextEnd: Date;
-};

--- a/frontend/src/modules/core/components/calendar/AppCalendar.tsx
+++ b/frontend/src/modules/core/components/calendar/AppCalendar.tsx
@@ -2,6 +2,8 @@ import ChevronLeftIcon from 'bootstrap-icons/icons/chevron-left.svg?react';
 import ChevronRightIcon from 'bootstrap-icons/icons/chevron-right.svg?react';
 import {
   DndContext,
+  DragOverlay,
+  pointerWithin,
   type DragEndEvent,
   type DragOverEvent,
   type DragStartEvent,
@@ -43,19 +45,54 @@ type Props = {
 };
 export function AppCalendar({ events, buttons, onEventDrop }: Props) {
   const DAY_MS = 24 * 60 * 60 * 1000;
+  const DRAG_CURSOR_Y_NUDGE = 4;
   const [currentMonth, setCurrentMonth] = React.useState({
     month: new Date().getMonth(),
     year: new Date().getFullYear(),
   });
   const [previousMonth, setPreviousMonth] = React.useState(currentMonth);
   const [dropPreviewDays, setDropPreviewDays] = React.useState<number[]>([]);
+  const [activeDragEventId, setActiveDragEventId] = React.useState<string | undefined>(undefined);
+  const [activeDragOverlay, setActiveDragOverlay] = React.useState<
+    { title: string; spanDays: number; anchorOffset: number } | undefined
+  >(undefined);
+  const [activeDragPointerOffsetY, setActiveDragPointerOffsetY] = React.useState(0);
   const calendarRef = React.useRef<HTMLDivElement>(null);
   const [tileWidth, setTileWidth] = React.useState(0);
+  const [dragBlockHeight, setDragBlockHeight] = React.useState(32);
+  const [dragBlockRowGap, setDragBlockRowGap] = React.useState(4);
+  const [dragWeekRowStep, setDragWeekRowStep] = React.useState(120);
 
   function updateTileWidth() {
     const calendarWidth = calendarRef.current?.offsetWidth ?? 700;
     // oxlint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
     setTileWidth(calendarWidth / 7);
+
+    const eventBlock = calendarRef.current?.querySelector<HTMLElement>('[data-calendar-event-block]');
+    if (eventBlock) {
+      // oxlint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+      setDragBlockHeight(eventBlock.getBoundingClientRect().height);
+    }
+
+    const eventRows = calendarRef.current?.querySelector<HTMLElement>('[data-calendar-event-rows]');
+    if (eventRows) {
+      const rowGap = Number.parseFloat(window.getComputedStyle(eventRows).rowGap || '0');
+      if (Number.isFinite(rowGap)) {
+        // oxlint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+        setDragBlockRowGap(rowGap);
+      }
+    }
+
+    const dayTiles = calendarRef.current?.querySelectorAll<HTMLElement>('[data-calendar-day-tile]');
+    if (dayTiles && dayTiles.length > 7) {
+      const firstRowTop = dayTiles[0].getBoundingClientRect().top;
+      const secondRowTop = dayTiles[7].getBoundingClientRect().top;
+      const weekStep = secondRowTop - firstRowTop;
+      if (Number.isFinite(weekStep) && weekStep > 0) {
+        // oxlint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+        setDragWeekRowStep(weekStep);
+      }
+    }
   }
 
   React.useEffect(() => {
@@ -103,6 +140,52 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
     return Array.from({ length: spanDays }, (_, index) => previewStartDayUtc + index * DAY_MS);
   }
 
+  function getWeekdayColumn(dayUtc: number): number {
+    const utcWeekday = new Date(dayUtc).getUTCDay();
+    return utcWeekday === 0 ? 6 : utcWeekday - 1;
+  }
+
+  function buildWeeklyOverlaySegments(
+    previewStartDayUtc: number,
+    spanDays: number
+  ): Array<{ startColumn: number; length: number }> {
+    const segments: Array<{ startColumn: number; length: number }> = [];
+    let remainingDays = spanDays;
+    let currentDayUtc = previewStartDayUtc;
+
+    while (remainingDays > 0) {
+      const startColumn = getWeekdayColumn(currentDayUtc);
+      const daysUntilWeekEnd = 7 - startColumn;
+      const length = Math.min(remainingDays, daysUntilWeekEnd);
+      segments.push({ startColumn, length });
+      remainingDays -= length;
+      currentDayUtc += length * DAY_MS;
+    }
+
+    return segments;
+  }
+
+  function getOverlayAnchorPosition(segments: Array<{ startColumn: number; length: number }>, anchorOffset: number) {
+    let coveredDays = 0;
+    for (let row = 0; row < segments.length; row++) {
+      const segment = segments[row];
+      if (anchorOffset < coveredDays + segment.length) {
+        return {
+          row,
+          column: segment.startColumn + (anchorOffset - coveredDays),
+        };
+      }
+      coveredDays += segment.length;
+    }
+
+    const lastRow = Math.max(0, segments.length - 1);
+    const lastSegment = segments[lastRow];
+    return {
+      row: lastRow,
+      column: Math.max(0, lastSegment.startColumn + lastSegment.length - 1),
+    };
+  }
+
   function handleDragStart(event: DragStartEvent) {
     if (!onEventDrop) {
       return;
@@ -110,10 +193,48 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
 
     const { eventId, sourceDayUtc } = event.active.data.current ?? {};
     if (typeof eventId !== 'string' || typeof sourceDayUtc !== 'number') {
+      setActiveDragEventId(undefined);
+      setActiveDragOverlay(undefined);
       setDropPreviewDays([]);
       return;
     }
 
+    const draggedEvent = events.find((calendarEvent) => calendarEvent.id === eventId);
+    if (!draggedEvent) {
+      setActiveDragEventId(undefined);
+      setActiveDragOverlay(undefined);
+      setDropPreviewDays([]);
+      return;
+    }
+
+    const startDayUtc = dateToUtcDay(draggedEvent.start);
+    const anchorOffset = Math.floor((sourceDayUtc - startDayUtc) / DAY_MS);
+    const initialTop = event.active.rect.current.initial?.top;
+    const activatorEvent = event.activatorEvent;
+    let pointerY: number | undefined;
+    if ('clientY' in activatorEvent && typeof activatorEvent.clientY === 'number') {
+      pointerY = activatorEvent.clientY;
+    } else if ('touches' in activatorEvent) {
+      const touchEvent = activatorEvent as { touches?: Array<{ clientY: number }> };
+      if (touchEvent.touches && touchEvent.touches.length > 0) {
+        pointerY = touchEvent.touches[0].clientY;
+      }
+    } else if ('changedTouches' in activatorEvent) {
+      const changedTouchEvent = activatorEvent as { changedTouches?: Array<{ clientY: number }> };
+      if (changedTouchEvent.changedTouches && changedTouchEvent.changedTouches.length > 0) {
+        pointerY = changedTouchEvent.changedTouches[0].clientY;
+      }
+    }
+    const nextPointerOffsetY =
+      typeof pointerY === 'number' && typeof initialTop === 'number' ? pointerY - initialTop : dragBlockHeight / 2;
+
+    setActiveDragEventId(eventId);
+    setActiveDragOverlay({
+      title: draggedEvent.title,
+      spanDays: getVisibleSpanDays(draggedEvent),
+      anchorOffset,
+    });
+    setActiveDragPointerOffsetY(nextPointerOffsetY);
     setDropPreviewDays(buildDropPreview(eventId, sourceDayUtc, sourceDayUtc));
   }
 
@@ -139,10 +260,16 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
   }
 
   function handleDragCancel() {
+    setActiveDragEventId(undefined);
+    setActiveDragOverlay(undefined);
+    setActiveDragPointerOffsetY(0);
     setDropPreviewDays([]);
   }
 
   function handleDragEnd(event: DragEndEvent) {
+    setActiveDragEventId(undefined);
+    setActiveDragOverlay(undefined);
+    setActiveDragPointerOffsetY(0);
     setDropPreviewDays([]);
     if (!onEventDrop || !event.over?.id) {
       return;
@@ -185,6 +312,14 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
   }
 
   const eventsWithRows = React.useMemo(() => assignEventsToRows(events), [events]);
+  const overlaySegments =
+    activeDragOverlay && dropPreviewDays.length > 0
+      ? buildWeeklyOverlaySegments(dropPreviewDays[0], activeDragOverlay.spanDays)
+      : [];
+  const overlayAnchor =
+    activeDragOverlay && overlaySegments.length > 0
+      ? getOverlayAnchorPosition(overlaySegments, activeDragOverlay.anchorOffset)
+      : { row: 0, column: 0 };
 
   const defaultButtons = [
     <AppButton
@@ -243,6 +378,7 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
           transition={{ duration: 0.3, ease: 'easeInOut' }}
         >
           <DndContext
+            collisionDetection={pointerWithin}
             sensors={sensors}
             onDragStart={handleDragStart}
             onDragOver={handleDragOver}
@@ -264,10 +400,40 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
                   enableDragAndDrop={Boolean(onEventDrop)}
                   dayDropId={`calendar-day-${dateToUtcDay(date)}`}
                   isDropPreview={dropPreviewDays.includes(dateToUtcDay(date))}
+                  activeDragEventId={activeDragEventId}
                   key={date.toString()}
                 />
               ))}
             </div>
+            <DragOverlay adjustScale={false}>
+              {activeDragOverlay ? (
+                <div
+                  className="pointer-events-none"
+                  style={{
+                    marginLeft: -(overlayAnchor.column * tileWidth),
+                    marginTop: DRAG_CURSOR_Y_NUDGE - activeDragPointerOffsetY - overlayAnchor.row * dragWeekRowStep,
+                  }}
+                >
+                  <div
+                    className="flex flex-col"
+                    style={{ gap: Math.max(dragBlockRowGap, dragWeekRowStep - dragBlockHeight) }}
+                  >
+                    {overlaySegments.map((segment, index) => (
+                      <div
+                        key={`${activeDragOverlay.title}-${index}`}
+                        className="h-8 rounded-lg bg-gray-500/90 p-2 text-sm text-white shadow-lg"
+                        style={{
+                          width: Math.max(40, segment.length * tileWidth - 20),
+                          marginLeft: segment.startColumn * tileWidth,
+                        }}
+                      >
+                        <div className="truncate">{index === 0 ? activeDragOverlay.title : ''}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </DragOverlay>
           </DndContext>
         </motion.div>
       </AnimatePresence>

--- a/frontend/src/modules/core/components/calendar/AppCalendar.tsx
+++ b/frontend/src/modules/core/components/calendar/AppCalendar.tsx
@@ -54,6 +54,9 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
   const [previousMonth, setPreviousMonth] = React.useState(currentMonth);
   const [dropPreviewDays, setDropPreviewDays] = React.useState<number[]>([]);
   const [activeDragEventId, setActiveDragEventId] = React.useState<string | undefined>(undefined);
+  const [pendingDrop, setPendingDrop] = React.useState<
+    { eventId: string; nextStartMs: number; nextEndMs: number } | undefined
+  >(undefined);
   const [activeDragOverlay, setActiveDragOverlay] = React.useState<
     { title: string; spanDays: number; anchorOffset: number } | undefined
   >(undefined);
@@ -113,17 +116,6 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
       viewport.removeEventListener('resize', handleViewportResize);
     };
   }, [updateTileWidth]);
-
-  function getInitialTopFromActivatorEvent(activatorEvent: Event): number | undefined {
-    const target = activatorEvent.target;
-    if (!(target instanceof Element)) {
-      return undefined;
-    }
-
-    const eventBlock = target.closest('[data-calendar-event-block]');
-    const element = eventBlock ?? target;
-    return element.getBoundingClientRect().top;
-  }
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { delay: 0, tolerance: 0 } }),
@@ -228,26 +220,10 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
 
     const startDayUtc = dateToUtcDay(draggedEvent.start);
     const anchorOffset = Math.floor((sourceDayUtc - startDayUtc) / DAY_MS);
-    const activatorEvent = event.activatorEvent;
-    const initialTop = event.active.rect.current.initial?.top ?? getInitialTopFromActivatorEvent(activatorEvent);
-    let pointerY: number | undefined;
-    if ('clientY' in activatorEvent && typeof activatorEvent.clientY === 'number') {
-      pointerY = activatorEvent.clientY;
-    } else if ('touches' in activatorEvent) {
-      const touchEvent = activatorEvent as { touches?: Array<{ clientY: number }> };
-      if (touchEvent.touches && touchEvent.touches.length > 0) {
-        pointerY = touchEvent.touches[0].clientY;
-      }
-    } else if ('changedTouches' in activatorEvent) {
-      const changedTouchEvent = activatorEvent as { changedTouches?: Array<{ clientY: number }> };
-      if (changedTouchEvent.changedTouches && changedTouchEvent.changedTouches.length > 0) {
-        pointerY = changedTouchEvent.changedTouches[0].clientY;
-      }
-    }
-    const nextPointerOffsetY =
-      typeof pointerY === 'number' && typeof initialTop === 'number' ? pointerY - initialTop : dragBlockHeight / 2;
+    const nextPointerOffsetY = dragBlockHeight * 2.3;
 
     setActiveDragEventId(eventId);
+    setPendingDrop(undefined);
     setActiveDragOverlay({
       title: draggedEvent.title,
       spanDays: getVisibleSpanDays(draggedEvent),
@@ -283,36 +259,61 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
     setActiveDragOverlay(undefined);
     setActiveDragPointerOffsetY(0);
     setDropPreviewDays([]);
+    setPendingDrop(undefined);
   }
 
-  function handleDragEnd(event: DragEndEvent) {
-    setActiveDragEventId(undefined);
-    setActiveDragOverlay(undefined);
-    setActiveDragPointerOffsetY(0);
-    setDropPreviewDays([]);
+  async function handleDragEnd(event: DragEndEvent) {
     if (!onEventDrop || !event.over?.id) {
+      setActiveDragEventId(undefined);
+      setActiveDragOverlay(undefined);
+      setActiveDragPointerOffsetY(0);
+      setDropPreviewDays([]);
+      setPendingDrop(undefined);
       return;
     }
 
     const { eventId, sourceDayUtc } = event.active.data.current ?? {};
     if (typeof eventId !== 'string' || typeof sourceDayUtc !== 'number') {
+      setActiveDragEventId(undefined);
+      setActiveDragOverlay(undefined);
+      setActiveDragPointerOffsetY(0);
+      setDropPreviewDays([]);
+      setPendingDrop(undefined);
       return;
     }
 
     const targetDayId = String(event.over.id);
     const targetDayUtc = getDayNumberFromDropId(targetDayId);
     if (targetDayUtc === undefined) {
+      setActiveDragEventId(undefined);
+      setActiveDragOverlay(undefined);
+      setActiveDragPointerOffsetY(0);
+      setDropPreviewDays([]);
+      setPendingDrop(undefined);
       return;
     }
 
     if (targetDayUtc === sourceDayUtc) {
+      setActiveDragEventId(undefined);
+      setActiveDragOverlay(undefined);
+      setActiveDragPointerOffsetY(0);
+      setDropPreviewDays([]);
+      setPendingDrop(undefined);
       return;
     }
 
     const draggedEvent = events.find((calendarEvent) => calendarEvent.id === eventId);
     if (!draggedEvent) {
+      setActiveDragEventId(undefined);
+      setActiveDragOverlay(undefined);
+      setActiveDragPointerOffsetY(0);
+      setDropPreviewDays([]);
+      setPendingDrop(undefined);
       return;
     }
+
+    setActiveDragOverlay(undefined);
+    setActiveDragPointerOffsetY(0);
 
     const dayDelta = Math.round((targetDayUtc - sourceDayUtc) / DAY_MS);
 
@@ -320,15 +321,45 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
     const nextEnd = new Date(draggedEvent.end);
     nextStart.setUTCDate(nextStart.getUTCDate() + dayDelta);
     nextEnd.setUTCDate(nextEnd.getUTCDate() + dayDelta);
+    setPendingDrop({ eventId, nextStartMs: nextStart.getTime(), nextEndMs: nextEnd.getTime() });
 
-    void onEventDrop({
-      event: draggedEvent,
-      sourceDate: new Date(sourceDayUtc),
-      targetDate: new Date(targetDayUtc),
-      nextStart,
-      nextEnd,
-    });
+    try {
+      await Promise.resolve(
+        onEventDrop({
+          event: draggedEvent,
+          sourceDate: new Date(sourceDayUtc),
+          targetDate: new Date(targetDayUtc),
+          nextStart,
+          nextEnd,
+        })
+      );
+    } catch (error) {
+      setActiveDragEventId(undefined);
+      setDropPreviewDays([]);
+      setPendingDrop(undefined);
+      throw error;
+    }
   }
+
+  React.useEffect(() => {
+    if (!pendingDrop) {
+      return;
+    }
+
+    const updatedEvent = events.find((calendarEvent) => calendarEvent.id === pendingDrop.eventId);
+    if (!updatedEvent) {
+      return;
+    }
+
+    if (
+      updatedEvent.start.getTime() === pendingDrop.nextStartMs &&
+      updatedEvent.end.getTime() === pendingDrop.nextEndMs
+    ) {
+      setActiveDragEventId(undefined);
+      setDropPreviewDays([]);
+      setPendingDrop(undefined);
+    }
+  }, [events, pendingDrop]);
 
   const eventsWithRows = React.useMemo(() => assignEventsToRows(events), [events]);
   const displayedMonthDays = React.useMemo(() => getDaysInMonth(currentMonth), [currentMonth]);
@@ -486,7 +517,7 @@ export function AppCalendar({ events, buttons, onEventDrop }: Props) {
                 />
               ))}
             </div>
-            <DragOverlay adjustScale={false}>
+            <DragOverlay adjustScale={false} dropAnimation={null}>
               {activeDragOverlay && overlaySegments.length > 0 ? (
                 <div
                   className="pointer-events-none"

--- a/frontend/src/modules/core/components/calendar/AppCalendar.tsx
+++ b/frontend/src/modules/core/components/calendar/AppCalendar.tsx
@@ -1,5 +1,15 @@
 import ChevronLeftIcon from 'bootstrap-icons/icons/chevron-left.svg?react';
 import ChevronRightIcon from 'bootstrap-icons/icons/chevron-right.svg?react';
+import {
+  DndContext,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
 import { AnimatePresence, motion } from 'motion/react';
 import React from 'react';
 
@@ -29,13 +39,16 @@ function isOverlapping(a: CalendarEvent, b: CalendarEvent): boolean {
 type Props = {
   events: CalendarEvent[];
   buttons?: (predefinedButtons: React.ReactNode[]) => React.ReactNode[];
+  onEventDrop?: (payload: CalendarEventDropPayload) => Promise<void> | void;
 };
-export function AppCalendar({ events, buttons }: Props) {
+export function AppCalendar({ events, buttons, onEventDrop }: Props) {
+  const DAY_MS = 24 * 60 * 60 * 1000;
   const [currentMonth, setCurrentMonth] = React.useState({
     month: new Date().getMonth(),
     year: new Date().getFullYear(),
   });
   const [previousMonth, setPreviousMonth] = React.useState(currentMonth);
+  const [dropPreviewDays, setDropPreviewDays] = React.useState<number[]>([]);
   const calendarRef = React.useRef<HTMLDivElement>(null);
   const [tileWidth, setTileWidth] = React.useState(0);
 
@@ -55,6 +68,121 @@ export function AppCalendar({ events, buttons }: Props) {
       window.removeEventListener('resize', updateTileWidth);
     };
   }, []);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 8 } })
+  );
+
+  function getDayNumberFromDropId(dropId: string): number | undefined {
+    if (!dropId.startsWith('calendar-day-')) {
+      return undefined;
+    }
+    const parsedDay = Number(dropId.replace('calendar-day-', ''));
+    return Number.isFinite(parsedDay) ? parsedDay : undefined;
+  }
+
+  function getVisibleSpanDays(calendarEvent: CalendarEvent): number {
+    const startDayUtc = dateToUtcDay(calendarEvent.start);
+    const endAtMidnight = calendarEvent.end.getHours() === 0 && calendarEvent.end.getMinutes() === 0;
+    const endDayUtc = dateToUtcDay(calendarEvent.end) - (endAtMidnight ? DAY_MS : 0);
+    return Math.max(1, Math.floor((endDayUtc - startDayUtc) / DAY_MS) + 1);
+  }
+
+  function buildDropPreview(activeEventId: string, sourceDayUtc: number, targetDayUtc: number): number[] {
+    const draggedEvent = events.find((calendarEvent) => calendarEvent.id === activeEventId);
+    if (!draggedEvent) {
+      return [];
+    }
+
+    const startDayUtc = dateToUtcDay(draggedEvent.start);
+    const anchorOffset = Math.floor((sourceDayUtc - startDayUtc) / DAY_MS);
+    const previewStartDayUtc = targetDayUtc - anchorOffset * DAY_MS;
+    const spanDays = getVisibleSpanDays(draggedEvent);
+
+    return Array.from({ length: spanDays }, (_, index) => previewStartDayUtc + index * DAY_MS);
+  }
+
+  function handleDragStart(event: DragStartEvent) {
+    if (!onEventDrop) {
+      return;
+    }
+
+    const { eventId, sourceDayUtc } = event.active.data.current ?? {};
+    if (typeof eventId !== 'string' || typeof sourceDayUtc !== 'number') {
+      setDropPreviewDays([]);
+      return;
+    }
+
+    setDropPreviewDays(buildDropPreview(eventId, sourceDayUtc, sourceDayUtc));
+  }
+
+  function handleDragOver(event: DragOverEvent) {
+    if (!onEventDrop || !event.over?.id) {
+      setDropPreviewDays([]);
+      return;
+    }
+
+    const { eventId, sourceDayUtc } = event.active.data.current ?? {};
+    if (typeof eventId !== 'string' || typeof sourceDayUtc !== 'number') {
+      setDropPreviewDays([]);
+      return;
+    }
+
+    const targetDayUtc = getDayNumberFromDropId(String(event.over.id));
+    if (targetDayUtc === undefined) {
+      setDropPreviewDays([]);
+      return;
+    }
+
+    setDropPreviewDays(buildDropPreview(eventId, sourceDayUtc, targetDayUtc));
+  }
+
+  function handleDragCancel() {
+    setDropPreviewDays([]);
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setDropPreviewDays([]);
+    if (!onEventDrop || !event.over?.id) {
+      return;
+    }
+
+    const { eventId, sourceDayUtc } = event.active.data.current ?? {};
+    if (typeof eventId !== 'string' || typeof sourceDayUtc !== 'number') {
+      return;
+    }
+
+    const targetDayId = String(event.over.id);
+    const targetDayUtc = getDayNumberFromDropId(targetDayId);
+    if (targetDayUtc === undefined) {
+      return;
+    }
+
+    if (targetDayUtc === sourceDayUtc) {
+      return;
+    }
+
+    const draggedEvent = events.find((calendarEvent) => calendarEvent.id === eventId);
+    if (!draggedEvent) {
+      return;
+    }
+
+    const dayDelta = Math.round((targetDayUtc - sourceDayUtc) / DAY_MS);
+
+    const nextStart = new Date(draggedEvent.start);
+    const nextEnd = new Date(draggedEvent.end);
+    nextStart.setUTCDate(nextStart.getUTCDate() + dayDelta);
+    nextEnd.setUTCDate(nextEnd.getUTCDate() + dayDelta);
+
+    void onEventDrop({
+      event: draggedEvent,
+      sourceDate: new Date(sourceDayUtc),
+      targetDate: new Date(targetDayUtc),
+      nextStart,
+      nextEnd,
+    });
+  }
 
   const eventsWithRows = React.useMemo(() => assignEventsToRows(events), [events]);
 
@@ -114,22 +242,33 @@ export function AppCalendar({ events, buttons }: Props) {
           exit={{ opacity: 0, scaleX: 0, transformOrigin: animateDirection === 'left' ? '0% 50%' : '100% 50%' }}
           transition={{ duration: 0.3, ease: 'easeInOut' }}
         >
-          <div ref={calendarRef} className="grid grid-cols-7 gap-1">
-            {weekDays.map((day) => (
-              <div key={day} className="truncate text-center">
-                {day}
-              </div>
-            ))}
-            {getDaysInMonth(currentMonth).map((date) => (
-              <AppCalendarTile
-                date={date}
-                eventsWithRows={eventsWithRows}
-                currentMonth={currentMonth}
-                tileWidth={tileWidth}
-                key={date.toString()}
-              />
-            ))}
-          </div>
+          <DndContext
+            sensors={sensors}
+            onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
+            onDragCancel={handleDragCancel}
+            onDragEnd={handleDragEnd}
+          >
+            <div ref={calendarRef} className="grid grid-cols-7 gap-1">
+              {weekDays.map((day) => (
+                <div key={day} className="truncate text-center">
+                  {day}
+                </div>
+              ))}
+              {getDaysInMonth(currentMonth).map((date) => (
+                <AppCalendarTile
+                  date={date}
+                  eventsWithRows={eventsWithRows}
+                  currentMonth={currentMonth}
+                  tileWidth={tileWidth}
+                  enableDragAndDrop={Boolean(onEventDrop)}
+                  dayDropId={`calendar-day-${dateToUtcDay(date)}`}
+                  isDropPreview={dropPreviewDays.includes(dateToUtcDay(date))}
+                  key={date.toString()}
+                />
+              ))}
+            </div>
+          </DndContext>
         </motion.div>
       </AnimatePresence>
     </div>
@@ -137,6 +276,7 @@ export function AppCalendar({ events, buttons }: Props) {
 }
 
 export type CalendarEvent = {
+  id?: string;
   title: string;
   start: Date;
   end: Date;
@@ -146,3 +286,11 @@ export type CalendarEvent = {
 };
 
 export type CalendarEventWithRow = CalendarEvent & { row: number };
+
+export type CalendarEventDropPayload = {
+  event: CalendarEvent;
+  sourceDate: Date;
+  targetDate: Date;
+  nextStart: Date;
+  nextEnd: Date;
+};

--- a/frontend/src/modules/core/components/calendar/AppCalendarTile.tsx
+++ b/frontend/src/modules/core/components/calendar/AppCalendarTile.tsx
@@ -22,10 +22,17 @@ type CalendarEventTilesProps = {
   eventsWithRows: CalendarEventWithRow[];
   tileWidth: number;
   enableDragAndDrop: boolean;
+  activeDragEventId?: string;
 };
-function CalendarEventTiles({ date, eventsWithRows, tileWidth, enableDragAndDrop }: CalendarEventTilesProps) {
+function CalendarEventTiles({
+  date,
+  eventsWithRows,
+  tileWidth,
+  enableDragAndDrop,
+  activeDragEventId,
+}: CalendarEventTilesProps) {
   const todaysEvents = getEventsForDate(date, eventsWithRows);
-  const rowCount = Math.max(...todaysEvents.map((event) => event.row + 1));
+  const rowCount = Math.max(0, ...todaysEvents.map((event) => event.row + 1));
 
   const eventTiles = [];
   for (let i = 0; i < rowCount; i++) {
@@ -60,14 +67,18 @@ function CalendarEventTiles({ date, eventsWithRows, tileWidth, enableDragAndDrop
       );
 
       const innerComponent = (
-        <div style={{ '--color': event.color } as React.CSSProperties} className={className}>
+        <div data-calendar-event-block style={{ '--color': event.color } as React.CSSProperties} className={className}>
           {textComponent}
         </div>
       );
 
       const renderedComponent =
         enableDragAndDrop && event.id ? (
-          <DraggableCalendarEvent eventId={event.id} sourceDayUtc={dateToUtcDay(date)}>
+          <DraggableCalendarEvent
+            eventId={event.id}
+            sourceDayUtc={dateToUtcDay(date)}
+            activeDragEventId={activeDragEventId}
+          >
             {innerComponent}
           </DraggableCalendarEvent>
         ) : (
@@ -96,16 +107,18 @@ type DraggableCalendarEventProps = {
   children: React.ReactNode;
   eventId: string;
   sourceDayUtc: number;
+  activeDragEventId?: string;
 };
-function DraggableCalendarEvent({ children, eventId, sourceDayUtc }: DraggableCalendarEventProps) {
+function DraggableCalendarEvent({ children, eventId, sourceDayUtc, activeDragEventId }: DraggableCalendarEventProps) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: `calendar-event-${eventId}-${sourceDayUtc}`,
     data: { eventId, sourceDayUtc },
   });
+  const isActiveDraggedEvent = activeDragEventId === eventId;
 
   const style = {
     transform: CSS.Translate.toString(transform),
-    opacity: isDragging ? 0.6 : 1,
+    opacity: isActiveDraggedEvent ? 0 : 1,
     cursor: isDragging ? 'grabbing' : 'grab',
   };
 
@@ -130,6 +143,7 @@ type Props = {
   enableDragAndDrop: boolean;
   dayDropId: string;
   isDropPreview: boolean;
+  activeDragEventId?: string;
 };
 export function AppCalendarTile({
   date,
@@ -139,6 +153,7 @@ export function AppCalendarTile({
   enableDragAndDrop,
   dayDropId,
   isDropPreview,
+  activeDragEventId,
 }: Props) {
   const isCurrentMonth = date.getMonth() === currentMonth.month;
   const isToday = dateToUtcDay(date) === dateToUtcDay(new Date());
@@ -147,6 +162,7 @@ export function AppCalendarTile({
 
   return (
     <div
+      data-calendar-day-tile
       ref={setNodeRef}
       className={cn(
         !isCurrentMonth ? 'bg-gray-100' : '',
@@ -161,12 +177,13 @@ export function AppCalendarTile({
           {date.getDate()}
         </div>
       </div>
-      <div className="-m-2 mt-2 grid grid-cols-1 gap-1">
+      <div data-calendar-event-rows className="-m-2 mt-2 grid grid-cols-1 gap-1">
         <CalendarEventTiles
           date={date}
           eventsWithRows={eventsWithRows}
           tileWidth={tileWidth}
           enableDragAndDrop={enableDragAndDrop}
+          activeDragEventId={activeDragEventId}
         />
       </div>
     </div>

--- a/frontend/src/modules/core/components/calendar/AppCalendarTile.tsx
+++ b/frontend/src/modules/core/components/calendar/AppCalendarTile.tsx
@@ -3,9 +3,9 @@ import { CSS } from '@dnd-kit/utilities';
 import React, { Fragment } from 'react';
 
 import { AppLink } from '@/core/components/AppLink';
-import { CalendarEventWithRow } from '@/core/components/calendar/AppCalendar';
 import { dateToUtcDay } from '@/core/lib/calendarUtils';
 import { cn } from '@/core/lib/utils';
+import type { CalendarEventWithRow } from './calendarTypes';
 
 function getEventsForDate(date: Date, eventsWithRows: CalendarEventWithRow[]): CalendarEventWithRow[] {
   const dayUtc = dateToUtcDay(date);

--- a/frontend/src/modules/core/components/calendar/AppCalendarTile.tsx
+++ b/frontend/src/modules/core/components/calendar/AppCalendarTile.tsx
@@ -1,4 +1,6 @@
-import { Fragment } from 'react/jsx-runtime';
+import { useDraggable, useDroppable } from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
+import React, { Fragment } from 'react';
 
 import { AppLink } from '@/core/components/AppLink';
 import { CalendarEventWithRow } from '@/core/components/calendar/AppCalendar';
@@ -19,8 +21,9 @@ type CalendarEventTilesProps = {
   date: Date;
   eventsWithRows: CalendarEventWithRow[];
   tileWidth: number;
+  enableDragAndDrop: boolean;
 };
-function CalendarEventTiles({ date, eventsWithRows, tileWidth }: CalendarEventTilesProps) {
+function CalendarEventTiles({ date, eventsWithRows, tileWidth, enableDragAndDrop }: CalendarEventTilesProps) {
   const todaysEvents = getEventsForDate(date, eventsWithRows);
   const rowCount = Math.max(...todaysEvents.map((event) => event.row + 1));
 
@@ -62,13 +65,22 @@ function CalendarEventTiles({ date, eventsWithRows, tileWidth }: CalendarEventTi
         </div>
       );
 
-      eventTiles.push(
-        event.link ? (
-          <AppLink href={event.link} variant="plain" key={`${event.title}-${i}`}>
+      const renderedComponent =
+        enableDragAndDrop && event.id ? (
+          <DraggableCalendarEvent eventId={event.id} sourceDayUtc={dateToUtcDay(date)}>
             {innerComponent}
+          </DraggableCalendarEvent>
+        ) : (
+          innerComponent
+        );
+
+      eventTiles.push(
+        event.link && !enableDragAndDrop ? (
+          <AppLink href={event.link} variant="plain" key={`${event.title}-${i}`}>
+            {renderedComponent}
           </AppLink>
         ) : (
-          <Fragment key={`${event.title}-${i}`}>{innerComponent}</Fragment>
+          <Fragment key={`${event.title}-${i}`}>{renderedComponent}</Fragment>
         )
       );
     } else if (eventsInRow.length === 0) {
@@ -80,22 +92,67 @@ function CalendarEventTiles({ date, eventsWithRows, tileWidth }: CalendarEventTi
   return eventTiles;
 }
 
+type DraggableCalendarEventProps = {
+  children: React.ReactNode;
+  eventId: string;
+  sourceDayUtc: number;
+};
+function DraggableCalendarEvent({ children, eventId, sourceDayUtc }: DraggableCalendarEventProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: `calendar-event-${eventId}-${sourceDayUtc}`,
+    data: { eventId, sourceDayUtc },
+  });
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    opacity: isDragging ? 0.6 : 1,
+    cursor: isDragging ? 'grabbing' : 'grab',
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn('touch-none', isDragging ? 'relative z-30' : '')}
+      {...attributes}
+      {...listeners}
+    >
+      {children}
+    </div>
+  );
+}
+
 type Props = {
   date: Date;
   eventsWithRows: CalendarEventWithRow[];
   currentMonth: { month: number; year: number };
   tileWidth: number;
+  enableDragAndDrop: boolean;
+  dayDropId: string;
+  isDropPreview: boolean;
 };
-export function AppCalendarTile({ date, eventsWithRows, currentMonth, tileWidth }: Props) {
+export function AppCalendarTile({
+  date,
+  eventsWithRows,
+  currentMonth,
+  tileWidth,
+  enableDragAndDrop,
+  dayDropId,
+  isDropPreview,
+}: Props) {
   const isCurrentMonth = date.getMonth() === currentMonth.month;
   const isToday = dateToUtcDay(date) === dateToUtcDay(new Date());
   const isSunday = date.getDay() === 0;
+  const { isOver, setNodeRef } = useDroppable({ id: dayDropId, disabled: !enableDragAndDrop });
 
   return (
     <div
+      ref={setNodeRef}
       className={cn(
         !isCurrentMonth ? 'bg-gray-100' : '',
-        isToday ? '!bg-primary-100 !border-primary-500' : '',
+        isToday ? 'bg-primary-100! border-primary-500!' : '',
+        enableDragAndDrop && isOver ? 'ring-2 ring-primary-500' : '',
+        enableDragAndDrop && isDropPreview ? 'ring-2 ring-primary-300 bg-primary-50' : '',
         'mb-3 h-full min-h-30 rounded-xl border border-gray-300 transition hover:bg-gray-100'
       )}
     >
@@ -105,7 +162,12 @@ export function AppCalendarTile({ date, eventsWithRows, currentMonth, tileWidth 
         </div>
       </div>
       <div className="-m-2 mt-2 grid grid-cols-1 gap-1">
-        <CalendarEventTiles date={date} eventsWithRows={eventsWithRows} tileWidth={tileWidth} />
+        <CalendarEventTiles
+          date={date}
+          eventsWithRows={eventsWithRows}
+          tileWidth={tileWidth}
+          enableDragAndDrop={enableDragAndDrop}
+        />
       </div>
     </div>
   );

--- a/frontend/src/modules/core/components/calendar/calendarTypes.ts
+++ b/frontend/src/modules/core/components/calendar/calendarTypes.ts
@@ -1,0 +1,20 @@
+// Calendar types for AppCalendar and related components
+
+export type CalendarEvent = {
+  id?: string;
+  title: string;
+  start: Date;
+  end: Date;
+  link?: string;
+  color?: string;
+};
+
+export type CalendarEventWithRow = CalendarEvent & { row: number };
+
+export type CalendarEventDropPayload = {
+  event: CalendarEvent;
+  sourceDate: Date;
+  targetDate: Date;
+  nextStart: Date;
+  nextEnd: Date;
+};

--- a/frontend/src/modules/cruise-schedule/components/CruiseCalendar.tsx
+++ b/frontend/src/modules/cruise-schedule/components/CruiseCalendar.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 
+import { AppButton } from '@/core/components/AppButton';
+import { toast } from '@/core/components/layout/toast';
 import { AppCalendar } from '@/core/components/calendar/AppCalendar';
+import { useUpdateCruiseByIdMutation } from '@/cruise-schedule/hooks/CruisesApiHooks';
 import { CruiseDto } from '@/cruise-schedule/models/CruiseDto';
+import { CruiseFormDto } from '@/cruise-schedule/models/CruiseFormDto';
 
 type Props = {
   cruises: CruiseDto[];
   buttons: React.ReactNode[];
 };
 export function CruiseCalendar({ cruises, buttons }: Props) {
+  const updateCruiseByIdMutation = useUpdateCruiseByIdMutation();
+  const [isCalendarEditMode, setIsCalendarEditMode] = React.useState(false);
+
   function getTitle(cruise: CruiseDto) {
     if (cruise.title || cruise.shipUnavailable) {
       return cruise.shipUnavailable ? `Blokada ${cruise.title}` : `Rejs ${cruise.title}`;
@@ -26,9 +33,51 @@ export function CruiseCalendar({ cruises, buttons }: Props) {
     return `hsl(${angle}deg 70% 50%)`;
   }
 
+  function mapCruiseToForm(cruise: CruiseDto, nextStart: Date, nextEnd: Date): CruiseFormDto {
+    return {
+      startDate: nextStart.toISOString(),
+      endDate: nextEnd.toISOString(),
+      managersTeam: {
+        mainCruiseManagerId: cruise.mainCruiseManagerId,
+        mainDeputyManagerId: cruise.mainDeputyManagerId,
+      },
+      cruiseApplicationsIds: cruise.cruiseApplicationsShortInfo.map((x) => x.id),
+      status: cruise.status,
+      title: cruise.title || '',
+      shipUnavailable: cruise.shipUnavailable,
+    };
+  }
+
+  async function handleCruiseDrop(payload: { event: { id?: string }; nextStart: Date; nextEnd: Date }) {
+    if (!payload.event.id) {
+      return;
+    }
+
+    const cruise = cruises.find((item) => item.id === payload.event.id);
+    if (!cruise) {
+      return;
+    }
+
+    await updateCruiseByIdMutation.mutateAsync(
+      {
+        id: cruise.id,
+        cruise: mapCruiseToForm(cruise, payload.nextStart, payload.nextEnd),
+      },
+      {
+        onSuccess: () => {
+          toast.success('Termin rejsu został zmieniony.');
+        },
+        onError: () => {
+          toast.error('Nie udało się zmienić terminu rejsu.');
+        },
+      }
+    );
+  }
+
   const events = React.useMemo(
     () =>
       cruises.map((cruise) => ({
+        id: cruise.id,
         title: getTitle(cruise),
         start: new Date(cruise.startDate),
         end: new Date(cruise.endDate),
@@ -38,5 +87,21 @@ export function CruiseCalendar({ cruises, buttons }: Props) {
     [cruises]
   );
 
-  return <AppCalendar events={events} buttons={(predefinedButtons) => [buttons, ...predefinedButtons]} />;
+  return (
+    <AppCalendar
+      events={events}
+      buttons={(predefinedButtons) => [
+        <AppButton
+          key="calendar-edit-mode"
+          variant={isCalendarEditMode ? 'primary' : 'primaryOutline'}
+          onClick={() => setIsCalendarEditMode((prev) => !prev)}
+        >
+          {isCalendarEditMode ? 'Wyłącz tryb edycji kalendarza' : 'Włącz tryb edycji kalendarza'}
+        </AppButton>,
+        buttons,
+        ...predefinedButtons,
+      ]}
+      onEventDrop={isCalendarEditMode ? handleCruiseDrop : undefined}
+    />
+  );
 }

--- a/frontend/src/modules/cruise-schedule/hooks/CruisesApiHooks.tsx
+++ b/frontend/src/modules/cruise-schedule/hooks/CruisesApiHooks.tsx
@@ -83,6 +83,19 @@ export function useUpdateCruiseMutation(id: string) {
   });
 }
 
+export function useUpdateCruiseByIdMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, cruise }: { id: string; cruise: CruiseFormDto }) => {
+      await client.patch(`/api/Cruises/${id}`, cruise);
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['cruises'] });
+      queryClient.invalidateQueries({ queryKey: ['cruises', variables.id] });
+    },
+  });
+}
+
 export function useConfirmCruiseMutation(id: string) {
   const queryClient = useQueryClient();
   return useMutation({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
       '@base-ui/react':
         specifier: ^1.1.0
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@grafana/faro-web-sdk':
         specifier: ^2.2.3
         version: 2.3.1
@@ -271,6 +277,22 @@ packages:
     engines: {node: '>=20.0.0', yarn: '>=1.22.18'}
     peerDependencies:
       storybook: ^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -3322,6 +3344,24 @@ snapshots:
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@emnapi/core@1.9.1':
     dependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds calendar drag-and-drop using `@dnd-kit/core`, letting users in edit mode reposition cruises by dragging event tiles to new days. The overlay rendering (multi-week segment split, anchor offset alignment) and `pendingDrop` optimistic-state pattern are well thought out. Two minor concerns remain: the zero-tolerance touch sensor can block vertical scroll on mobile, and there is no timeout fallback if the server returns timestamps that don't exactly match `pendingDrop`, which would leave the event permanently invisible.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor improvements recommended for mobile UX and resilience.

Two P2 findings remain: zero touch tolerance that can block mobile page scroll on draggable tiles, and no timeout fallback if the server returns timestamps that don't exactly match pendingDrop (leaving the event permanently invisible). Neither is catastrophic but both are user-visible quality issues that are straightforward to address.

frontend/src/modules/core/components/calendar/AppCalendar.tsx — sensor activation constraints (lines 120-123) and the pendingDrop useEffect (lines 343-361)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/modules/core/components/calendar/AppCalendar.tsx | Core DnD orchestration — DndContext, sensors, pendingDrop pattern, and viewport-based tile measurements; mobile sensor config and missing timeout fallback are worth addressing |
| frontend/src/modules/core/components/calendar/AppCalendarTile.tsx | Adds useDroppable and DraggableCalendarEvent wrappers; logic for hiding the active-drag event tile is correct |
| frontend/src/modules/core/components/calendar/calendarTypes.ts | Adds CalendarEventDropPayload type; clean and consistent with usage |
| frontend/src/modules/cruise-schedule/components/CruiseCalendar.tsx | Adds edit-mode toggle and handleCruiseDrop handler wired to mutation; straightforward integration |
| frontend/src/modules/cruise-schedule/hooks/CruisesApiHooks.tsx | Adds useUpdateCruiseByIdMutation with proper cache invalidation for both list and detail queries |
| frontend/package.json | Adds @dnd-kit/core and @dnd-kit/utilities dependencies |
| pnpm-lock.yaml | Lockfile updated to match new dnd-kit dependencies |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant DndContext
    participant AppCalendar
    participant CruiseCalendar
    participant Mutation as useUpdateCruiseByIdMutation
    participant Server

    User->>DndContext: pointerdown on event tile
    DndContext->>AppCalendar: onDragStart → setActiveDragEventId, setActiveDragOverlay
    User->>DndContext: move pointer over day tile
    DndContext->>AppCalendar: onDragOver → setDropPreviewDays
    User->>DndContext: release pointer
    DndContext->>AppCalendar: onDragEnd → setPendingDrop, call onEventDrop
    AppCalendar->>CruiseCalendar: onEventDrop(payload)
    CruiseCalendar->>Mutation: mutateAsync({id, cruise})
    Mutation->>Server: PATCH /api/Cruises/{id}
    Server-->>Mutation: 200 OK
    Mutation-->>CruiseCalendar: invalidateQueries(['cruises'])
    CruiseCalendar-->>AppCalendar: events prop updates
    AppCalendar->>AppCalendar: useEffect: timestamps match? → clear activeDragEventId
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/modules/core/components/calendar/AppCalendar.tsx
Line: 120-123

Comment:
**Zero delay/tolerance on sensors blocks mobile scroll**

Both sensors are configured with `delay: 0, tolerance: 0`. On touch devices this activates a drag the instant a finger touches any draggable event tile, preventing vertical page scrolling if the touch begins on an event. A small activation constraint (e.g. `delay: 150, tolerance: 5`) would let the browser distinguish a scroll gesture from a deliberate drag before handing control to dnd-kit.

```suggestion
  const sensors = useSensors(
    useSensor(PointerSensor, { activationConstraint: { delay: 0, tolerance: 5 } }),
    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 5 } })
  );
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/modules/core/components/calendar/AppCalendar.tsx
Line: 343-361

Comment:
**No timeout fallback for stuck `pendingDrop` state**

After a successful drop, `activeDragEventId` and `dropPreviewDays` are not cleared immediately — they stay set until the `events` prop updates with timestamps that exactly equal `pendingDrop.nextStartMs` / `nextEndMs`. If the server normalises dates in any way (strips milliseconds, adjusts timezone representation, etc.) the equality check on lines 354–356 will never be true, leaving the dragged event permanently invisible (`opacity: 0`) until the page is refreshed. Adding a timeout as a safety valve would recover this state automatically:

```suggestion
  React.useEffect(() => {
    if (!pendingDrop) {
      return;
    }

    const updatedEvent = events.find((calendarEvent) => calendarEvent.id === pendingDrop.eventId);
    if (!updatedEvent) {
      return;
    }

    if (
      updatedEvent.start.getTime() === pendingDrop.nextStartMs &&
      updatedEvent.end.getTime() === pendingDrop.nextEndMs
    ) {
      setActiveDragEventId(undefined);
      setDropPreviewDays([]);
      setPendingDrop(undefined);
      return;
    }

    // Safety fallback: if the server returned different timestamps,
    // clear the loading state after a short grace period.
    const timeout = setTimeout(() => {
      setActiveDragEventId(undefined);
      setDropPreviewDays([]);
      setPendingDrop(undefined);
    }, 3000);
    return () => clearTimeout(timeout);
  }, [events, pendingDrop]);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(calendar): run updateTitleWidth on m..."](https://github.com/vv01t3k/researchcruiseapp/commit/af1336d81fc017802245be97ffc8d661babe5933) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27359802)</sub>

<!-- /greptile_comment -->