### PR TITLE
Refactor: Improve group user actions and fix data sync

### DIFF
--- a/frontend/src/components/user-management/GroupActionSection.tsx
+++ b/frontend/src/components/user-management/GroupActionSection.tsx
@@ -39,6 +39,8 @@ export function GroupActionSection({ selectedUsers, allUsers, allowToRemoveUsers
       return;
     }
 
+    if (selectedUsers.length === 0) return;
+
     if (selectedUsers.some((user) => user.roles.includes(Role.Administrator))) {
       const selectedIds = new Set(selectedUsers.map((u) => u.id));
       const remainingAdmins = allUsers.filter((u) => !selectedIds.has(u.id) && u.roles.includes(Role.Administrator));
@@ -49,25 +51,18 @@ export function GroupActionSection({ selectedUsers, allUsers, allowToRemoveUsers
       }
     }
 
-    if (selectedUsers.length === 0) return;
+    const promises = selectedUsers.map((user) => deleteUserMutation.mutateAsync(user.id));
+    const results = await Promise.allSettled(promises);
+    const failedCount = results.filter((result) => result.status === 'rejected').length;
 
-    try {
-      const promises = selectedUsers.map((user) => deleteUserMutation.mutateAsync(user.id));
-      const results = await Promise.allSettled(promises);
-      const failedCount = results.filter((result) => result.status === 'rejected').length;
-
-      if (failedCount === 0) {
-        toast.success('Pomyślnie usunięto wszystkich wybranych użytkowników');
-      } else if (failedCount === selectedUsers.length) {
-        toast.error('Nie udało się usunąć żadnego z użytkowników');
-      } else {
-        toast.error(`Usunięto część osób. Błąd przy ${failedCount} użytkownikach`);
-      }
-    } catch {
-      toast.error('Wystąpił błąd podczas usuwania użytkowników');
-    } finally {
-      close();
+    if (failedCount === 0) {
+      toast.success('Pomyślnie usunięto wszystkich wybranych użytkowników');
+    } else if (failedCount === selectedUsers.length) {
+      toast.error('Nie udało się usunąć żadnego z użytkowników');
+    } else {
+      toast.error(`Usunięto część osób. Błąd przy ${failedCount} użytkownikach`);
     }
+    close();
   }
 
   async function handleAcceptSelectedUsers() {
@@ -77,21 +72,16 @@ export function GroupActionSection({ selectedUsers, allUsers, allowToRemoveUsers
       return;
     }
 
-    try {
-      const promises = usersToAccept.map((user) => acceptUserMutation.mutateAsync(user.id));
-      const results = await Promise.allSettled(promises);
-      const failedCount = results.filter((result) => result.status === 'rejected').length;
+    const promises = usersToAccept.map((user) => acceptUserMutation.mutateAsync(user.id));
+    const results = await Promise.allSettled(promises);
+    const failedCount = results.filter((result) => result.status === 'rejected').length;
 
-      if (failedCount === 0) {
-        toast.success('Pomyślnie zaakceptowano wszystkich wybranych użytkowników');
-      } else {
-        toast.error(`Nie udało się zaakceptować ${failedCount} użytkowników`);
-      }
-    } catch {
-      toast.error('Wystąpił błąd podczas akceptowania użytkowników');
-    } finally {
-      close();
+    if (failedCount === 0) {
+      toast.success('Pomyślnie zaakceptowano wszystkich wybranych użytkowników');
+    } else {
+      toast.error(`Nie udało się zaakceptować ${failedCount} użytkowników`);
     }
+    close();
   }
 
   async function handleUnAcceptSelectedUsers() {
@@ -101,21 +91,16 @@ export function GroupActionSection({ selectedUsers, allUsers, allowToRemoveUsers
       return;
     }
 
-    try {
-      const promises = usersToUnAccept.map((user) => unAcceptUserMutation.mutateAsync(user.id));
-      const results = await Promise.allSettled(promises);
-      const failedCount = results.filter((result) => result.status === 'rejected').length;
+    const promises = usersToUnAccept.map((user) => unAcceptUserMutation.mutateAsync(user.id));
+    const results = await Promise.allSettled(promises);
+    const failedCount = results.filter((result) => result.status === 'rejected').length;
 
-      if (failedCount === 0) {
-        toast.success('Pomyślnie usunięto akceptację wszystkich wybranych użytkowników');
-      } else {
-        toast.error(`Nie udało się usunąć akceptacji ${failedCount} użytkowników`);
-      }
-    } catch {
-      toast.error('Wystąpił błąd podczas usuwania akceptacji użytkowników');
-    } finally {
-      close();
+    if (failedCount === 0) {
+      toast.success('Pomyślnie usunięto akceptację wszystkich wybranych użytkowników');
+    } else {
+      toast.error(`Nie udało się usunąć akceptacji ${failedCount} użytkowników`);
     }
+    close();
   }
 
   return (

--- a/frontend/src/components/user-management/GroupActionSection.tsx
+++ b/frontend/src/components/user-management/GroupActionSection.tsx
@@ -47,39 +47,72 @@ export function GroupActionSection({ selectedUsers, allUsers, allowToRemoveUsers
       return;
     }
 
-    for (const user of selectedUsers) {
-      await deleteUserMutation
-        .mutateAsync(user.id, {
-          onSuccess: async () => {
-            close();
-          },
-        })
-        .catch(() => {});
+    if (selectedUsers.length === 0) return;
+
+    try {
+      const promises = selectedUsers.map((user) => deleteUserMutation.mutateAsync(user.id));
+      const results = await Promise.allSettled(promises);
+      const failedCount = results.filter((result) => result.status === 'rejected').length;
+
+      if (failedCount === 0) {
+        toast.success('Pomyślnie usunięto wszystkich wybranych użytkowników');
+      } else if (failedCount === selectedUsers.length) {
+        toast.error('Nie udało się usunąć żadnego z użytkowników');
+      } else {
+        toast.error(`Usunięto część osób. Błąd przy ${failedCount} użytkownikach`);
+      }
+    } catch {
+      toast.error('Wystąpił błąd podczas usuwania użytkowników');
+    } finally {
+      close();
     }
   }
 
   async function handleAcceptSelectedUsers() {
-    // TODO: probably need refactor - await blocks everything + close() is called x times + add toast
-    for (const user of selectedUsers.filter((user) => !user.accepted)) {
-      await acceptUserMutation
-        .mutateAsync(user.id, {
-          onSuccess: async () => {
-            close();
-          },
-        })
-        .catch(() => {});
+    const usersToAccept = selectedUsers.filter((user) => !user.accepted);
+    if (usersToAccept.length === 0) {
+      toast.success('Wszyscy zaznaczeni użytkownicy są już zaakceptowani');
+      return;
+    }
+
+    try {
+      const promises = usersToAccept.map((user) => acceptUserMutation.mutateAsync(user.id));
+      const results = await Promise.allSettled(promises);
+      const failedCount = results.filter((result) => result.status === 'rejected').length;
+
+      if (failedCount === 0) {
+        toast.success('Pomyślnie zaakceptowano wszystkich wybranych użytkowników');
+      } else {
+        toast.error(`Nie udało się zaakceptować ${failedCount} użytkowników`);
+      }
+    } catch {
+      toast.error('Wystąpił błąd podczas akceptowania użytkowników');
+    } finally {
+      close();
     }
   }
 
   async function handleUnAcceptSelectedUsers() {
-    for (const user of selectedUsers.filter((user) => user.accepted)) {
-      await unAcceptUserMutation
-        .mutateAsync(user.id, {
-          onSuccess: async () => {
-            close();
-          },
-        })
-        .catch(() => {});
+    const usersToUnAccept = selectedUsers.filter((user) => user.accepted);
+    if (usersToUnAccept.length === 0) {
+      toast.success('Wszyscy zaznaczeni użytkownicy są już niezaakceptowani');
+      return;
+    }
+
+    try {
+      const promises = usersToUnAccept.map((user) => unAcceptUserMutation.mutateAsync(user.id));
+      const results = await Promise.allSettled(promises);
+      const failedCount = results.filter((result) => result.status === 'rejected').length;
+
+      if (failedCount === 0) {
+        toast.success('Pomyślnie usunięto akceptację wszystkich wybranych użytkowników');
+      } else {
+        toast.error(`Nie udało się usunąć akceptacji ${failedCount} użytkowników`);
+      }
+    } catch {
+      toast.error('Wystąpił błąd podczas usuwania akceptacji użytkowników');
+    } finally {
+      close();
     }
   }
 

--- a/frontend/src/components/user-management/GroupActionSection.tsx
+++ b/frontend/src/components/user-management/GroupActionSection.tsx
@@ -39,12 +39,14 @@ export function GroupActionSection({ selectedUsers, allUsers, allowToRemoveUsers
       return;
     }
 
-    const selectedIds = new Set(selectedUsers.map((u) => u.id));
-    const remainingAdmins = allUsers.filter((u) => !selectedIds.has(u.id) && u.roles.includes(Role.Administrator));
-    if (remainingAdmins.length === 0) {
-      toast.error('Po usunięciu zaznaczonych użytkowników musi istnieć co najmniej jeden admin');
-      setDeletionConfirmed(false);
-      return;
+    if (selectedUsers.some((user) => user.roles.includes(Role.Administrator))) {
+      const selectedIds = new Set(selectedUsers.map((u) => u.id));
+      const remainingAdmins = allUsers.filter((u) => !selectedIds.has(u.id) && u.roles.includes(Role.Administrator));
+      if (remainingAdmins.length === 0) {
+        toast.error('Po usunięciu zaznaczonych użytkowników musi istnieć co najmniej jeden admin');
+        setDeletionConfirmed(false);
+        return;
+      }
     }
 
     if (selectedUsers.length === 0) return;

--- a/frontend/src/components/user-management/UserEditForm.tsx
+++ b/frontend/src/components/user-management/UserEditForm.tsx
@@ -138,11 +138,13 @@ export function UserEditForm({ user, allUsers, allowedRoles, allowToRemoveUsers,
       return;
     }
 
-    const remainingAdmins = allUsers.filter((u) => u.id !== user.id && u.roles.includes(Role.Administrator));
-    if (remainingAdmins.length === 0) {
-      toast.error('Musi istnieć co najmniej jeden admin');
-      setDeletionConfirmed(false);
-      return;
+    if (user.roles.includes(Role.Administrator)) {
+      const remainingAdmins = allUsers.filter((u) => u.id !== user.id && u.roles.includes(Role.Administrator));
+      if (remainingAdmins.length === 0) {
+        toast.error('Musi istnieć co najmniej jeden admin');
+        setDeletionConfirmed(false);
+        return;
+      }
     }
 
     const loading = toast.loading('Usuwanie użytkownika...');


### PR DESCRIPTION
Closes #275 

**Description of changes:**

* **Parallelized group actions:** Replaced sequential `await` inside loops with `Promise.allSettled` for (un)accepting and deleting users, improving performance.
* **Improved UX (Toasts):** Added precise toast notifications to handle success and failure states for group operations.
* **Fixed UI sync issue (F5 bug):** Moved the `close()` function call to the `finally` block. This ensures the modal closes - and triggers the list refresh - after all background requests have fully resolved, eliminating the need to manually refresh the page to see up-to-date data.
* **Fixed single account deletion logic** - The check for remaining Administrator accounts is now only performed when deleting an Administrator account. Previously it was impossible to delete any account as Shipowner - with this role you don't see Administrator accounts and trying to delete account triggered "Musi istnieć conajmniej jeden admin" error.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR parallelises group user operations (delete, accept, un-accept) using `Promise.allSettled`, adds granular toast notifications, fixes the modal-close/refresh timing by moving `close()` to `finally`, and correctly gates the "last admin" check so it only applies when the user being deleted actually holds the Administrator role — resolving the spurious error shown to Shipowner users.

<h3>Confidence Score: 4/5</h3>

Safe to merge; only P2 style/logic nits with no runtime impact.

All findings are P2: a dead catch block (Promise.allSettled never rejects) and a slightly misplaced empty-selection guard that is harmless today. Both core bug-fixes (admin check scoping, close() in finally) are correct. No P0/P1 issues found.

GroupActionSection.tsx — dead catch blocks and guard placement worth addressing before the pattern is replicated elsewhere.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/components/user-management/GroupActionSection.tsx | Parallelised group delete/accept/unaccept with Promise.allSettled, moved close() to finally, added granular toast messages. Minor: dead catch blocks (Promise.allSettled never rejects) and misplaced empty-selection guard. |
| frontend/src/components/user-management/UserEditForm.tsx | Admin-check guard is now correctly scoped to Administrator-role users only, fixing the false 'Musi istnieć co najmniej jeden admin' error for Shipowner accounts. No issues found. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant GAS as GroupActionSection
    participant API as API (mutateAsync ×N)
    participant Modal as Modal/List

    U->>GAS: Click "Delete / Accept / Un-accept"
    GAS->>GAS: Guard checks (admin rule, empty selection)
    GAS->>API: Promise.allSettled([mutateAsync(id1), mutateAsync(id2), ...])
    par Parallel requests
        API-->>GAS: resolve / reject (user 1)
    and
        API-->>GAS: resolve / reject (user 2)
    end
    GAS->>GAS: Count rejections → show success / partial / error toast
    GAS-->>Modal: finally → close() → triggers list refresh
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: frontend/src/components/user-management/GroupActionSection.tsx
Line: 66-68

Comment:
**Dead `catch` block — `Promise.allSettled` never rejects**

`Promise.allSettled` always resolves (never rejects), so any individual mutation failures are captured inside `results` as `{ status: 'rejected' }` entries — the `catch` block is unreachable. The same pattern applies to `handleAcceptSelectedUsers` (line 90) and `handleUnAcceptSelectedUsers` (line 114). These blocks can be safely removed to avoid misleading future readers into thinking there's a fallback error path here.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: frontend/src/components/user-management/GroupActionSection.tsx
Line: 52

Comment:
**Empty-selection guard placed after the admin check**

The `if (selectedUsers.length === 0) return;` guard sits below the admin-presence check. While functionally harmless today (an empty `selectedUsers` makes `.some()` return `false`, so the admin block is skipped), if this guard were ever removed, `Promise.allSettled([])` would resolve immediately with an empty results array, `failedCount === 0` would be true, and the success toast would fire for zero actual deletions. Moving the guard to the top of the function matches the early-return pattern already used in `handleAcceptSelectedUsers` and `handleUnAcceptSelectedUsers`.

```suggestion
    if (selectedUsers.length === 0) return;

    if (selectedUsers.some((user) => user.roles.includes(Role.Administrator))) {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: count remaining admins only when de..."](https://github.com/vv01t3k/researchcruiseapp/commit/03efe029fa4706b119cb176c814cbd8018f3376f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30184070)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->