### PR TITLE
feat: remove asterisks in details view

### DIFF
--- a/frontend/src/components/applications/application-details/ApplicationDetailsInformationSection.tsx
+++ b/frontend/src/components/applications/application-details/ApplicationDetailsInformationSection.tsx
@@ -17,21 +17,19 @@ export function ApplicationDetailsInformationSection() {
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <AppInput name="number" value={application.number} label="Numer zgłoszenia:" disabled />
         <AppDatePickerInput name="date" value={application.date} label="Data wysłania:" disabled />
-        <AppInput name="year" value={`${application.year}`} label="Rok rejsu:" disabled />
         <AppInput
           name="cruiseLeader"
           value={`${application.cruiseManagerFirstName} ${application.cruiseManagerLastName} (${application.cruiseManagerEmail})`}
           label="Kierownik:"
-          showRequiredAsterisk
           disabled
         />
         <AppInput
           name="deputyManager"
           value={`${application.deputyManagerFirstName} ${application.deputyManagerLastName} (${application.deputyManagerEmail})`}
           label="Zastępca kierownika:"
-          showRequiredAsterisk
           disabled
         />
+        <AppInput name="year" value={`${application.year}`} label="Rok rejsu:" disabled />
         <div className="grid grid-cols-1 gap-1">
           <strong>Formularze:</strong>
           <AppLink href={`/applications/${application.id}/formA`} disabled={!application.hasFormA}>


### PR DESCRIPTION
This pull request makes minor adjustments to the layout and required field indicators in the `ApplicationDetailsInformationSection` component. The main change is reordering the "Rok rejsu" (Year of Cruise) input field and removing the required asterisk from the "Kierownik" (Manager) and "Zastępca kierownika" (Deputy Manager) fields.

- UI adjustments:
  * Moved the `year` input field below the manager fields for improved logical grouping in the form.

- Required field indicators:
  * Removed the `showRequiredAsterisk` property from the manager and deputy manager input fields, so those fields no longer display as required.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes minor UI tweaks to the `ApplicationDetailsInformationSection` component: it removes the `showRequiredAsterisk` prop from the disabled "Kierownik" and "Zastępca kierownika" fields, and reorders the "Rok rejsu" input to appear after the manager fields. Since all fields in this component are `disabled` (read-only details view), the asterisk indicators served no functional purpose, so this is a clean cosmetic clean-up.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely cosmetic on a read-only details view component.

All fields in this component are disabled/read-only. Removing required asterisk indicators from disabled fields has no functional or validation impact. The field reordering is a minor layout improvement. No logic, data, or security concerns introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| frontend/src/components/applications/application-details/ApplicationDetailsInformationSection.tsx | Removed showRequiredAsterisk from disabled cruiseLeader and deputyManager fields, and reordered the year input below the manager fields — purely cosmetic, no logic affected. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ApplicationDetailsInformationSection] --> B[Numer zgłoszenia]
    A --> C[Data wysłania]
    A --> D[Kierownik\n❌ showRequiredAsterisk removed]
    A --> E[Zastępca kierownika\n❌ showRequiredAsterisk removed]
    A --> F[Rok rejsu\n📦 moved here from above managers]
    A --> G[Formularze links]
    A --> H[Status zgłoszenia]
    A --> I[Punkty]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["style: removed asterisks in details view"](https://github.com/vv01t3k/researchcruiseapp/commit/182adc56d558ea0f6ad3575115a1a46ad55f88f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30158885)</sub>

<!-- /greptile_comment -->