### PR TITLE
fix(sentry): keep seeded user credentials out of Sentry

### DIFF
--- a/backend/ResearchCruiseApp/Infrastructure/Persistence/Initialization/ApplicationDbContextInitializer.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Persistence/Initialization/ApplicationDbContextInitializer.cs
@@ -51,7 +51,13 @@ internal class ApplicationDbContextInitializer(
                 ?? false
             )
             {
-                logger.LogWarning("Seed User Created: {email} - {password}", user.Email, password);
+                // Information level keeps the credentials out of Sentry (MinimumEventLevel is
+                // Warning) while still printing them to the console for local dev.
+                logger.LogInformation(
+                    "Seed User Created: {email} - {password}",
+                    user.Email,
+                    password
+                );
             }
         }
     }

--- a/backend/ResearchCruiseApp/Infrastructure/Persistence/Initialization/ApplicationDbContextInitializer.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Persistence/Initialization/ApplicationDbContextInitializer.cs
@@ -4,6 +4,7 @@ using ResearchCruiseApp.Application.Common.Extensions;
 using ResearchCruiseApp.Application.ExternalServices;
 using ResearchCruiseApp.Domain.Entities;
 using ResearchCruiseApp.Infrastructure.Persistence.Initialization.InitialData;
+using ResearchCruiseApp.Infrastructure.Sentry;
 
 namespace ResearchCruiseApp.Infrastructure.Persistence.Initialization;
 
@@ -52,9 +53,10 @@ internal class ApplicationDbContextInitializer(
             )
             {
                 // Information level keeps the credentials out of Sentry (MinimumEventLevel is
-                // Warning) while still printing them to the console for local dev.
+                // Warning) while still printing them to the console for local dev. The prefix
+                // constant is what SentryConfiguration's filters match on.
                 logger.LogInformation(
-                    "Seed User Created: {email} - {password}",
+                    SentryConfiguration.SeedUserCreatedLogPrefix + ": {email} - {password}",
                     user.Email,
                     password
                 );

--- a/backend/ResearchCruiseApp/Infrastructure/Sentry/SentryConfiguration.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Sentry/SentryConfiguration.cs
@@ -46,10 +46,25 @@ public static class SentryConfiguration
             options.SetBeforeSend(
                 (@event, _) =>
                 {
+                    if (
+                        ContainsSeedUserCredentials(@event.Message?.Formatted)
+                        || ContainsSeedUserCredentials(@event.Message?.Message)
+                    )
+                    {
+                        return null;
+                    }
+
                     @event.ServerName = null;
                     return @event;
                 }
             );
+
+            options.SetBeforeBreadcrumb(
+                (breadcrumb, _) =>
+                    ContainsSeedUserCredentials(breadcrumb.Message) ? null : breadcrumb
+            );
+
+            options.SetBeforeSendLog(log => ContainsSeedUserCredentials(log.Message) ? null : log);
 
             options.SetBeforeSendTransaction(
                 (transaction, _) =>
@@ -117,6 +132,11 @@ public static class SentryConfiguration
 
         return environment.IsProduction() ? 0.1 : 0;
     }
+
+    // Seed user passwords are logged on purpose for local dev convenience
+    // (Database:LogUserPasswordsWhenSeeding) and must never leave the machine.
+    private static bool ContainsSeedUserCredentials(string? message) =>
+        message?.Contains("Seed User Created", StringComparison.OrdinalIgnoreCase) ?? false;
 
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value;

--- a/backend/ResearchCruiseApp/Infrastructure/Sentry/SentryConfiguration.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Sentry/SentryConfiguration.cs
@@ -46,9 +46,11 @@ public static class SentryConfiguration
             options.SetBeforeSend(
                 (@event, _) =>
                 {
+                    // Exception.ToString() also covers inner exception messages.
                     if (
                         ContainsSeedUserCredentials(@event.Message?.Formatted)
                         || ContainsSeedUserCredentials(@event.Message?.Message)
+                        || ContainsSeedUserCredentials(@event.Exception?.ToString())
                     )
                     {
                         return null;
@@ -133,10 +135,16 @@ public static class SentryConfiguration
         return environment.IsProduction() ? 0.1 : 0;
     }
 
+    /// <summary>
+    /// Prefix of the seed-credentials log message. ApplicationDbContextInitializer logs with it
+    /// and the filters above drop anything containing it, so both sides must use this constant.
+    /// </summary>
+    internal const string SeedUserCreatedLogPrefix = "Seed User Created";
+
     // Seed user passwords are logged on purpose for local dev convenience
     // (Database:LogUserPasswordsWhenSeeding) and must never leave the machine.
     private static bool ContainsSeedUserCredentials(string? message) =>
-        message?.Contains("Seed User Created", StringComparison.OrdinalIgnoreCase) ?? false;
+        message?.Contains(SeedUserCreatedLogPrefix, StringComparison.OrdinalIgnoreCase) ?? false;
 
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value;


### PR DESCRIPTION
## Problem

When `Database:LogUserPasswordsWhenSeeding=true`, the seeder logged `Seed User Created: <email> - <password>` at **Warning** level. Sentry is configured with `MinimumEventLevel = Warning`, so these plaintext passwords were sent to Sentry as error events (verified in the cruiseteam org). Sentry's server-side scrubbing redacts the email but **not** the password.

## Fix

- Log seed credentials at **Information** level — below Sentry's event threshold, still printed to the console for local dev.
- Defense in depth in `SentryConfiguration`: drop any `Seed User Created` message in `BeforeSend` (events), `BeforeBreadcrumb` (since `MinimumBreadcrumbLevel = Debug`, the Information log would still ride along as a breadcrumb on future events) and `BeforeSendLog` (since `EnableLogs = true` forwards Information logs to Sentry Logs).

## Notes

- Events already in Sentry still contain the passwords — delete them and rotate/reseed affected users where it matters.
- Verified with `dotnet build` (0 errors); runtime seeding path needs a SQL Server so it was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a credential-leak bug where seed user passwords (email + plaintext password) were being sent to Sentry at `Warning` level — right at `MinimumEventLevel`. The fix has two layers: the log level is downgraded to `Information` (below Sentry's capture threshold), and defense-in-depth filters are added in `BeforeSend`, `BeforeBreadcrumb`, and `BeforeSendLog` to drop anything matching the "Seed User Created" prefix. Both previous review concerns are addressed by the shared `SeedUserCreatedLogPrefix` constant and the `@event.Exception?.ToString()` check.

- **Log level change**: `LogWarning` → `LogInformation` in `ApplicationDbContextInitializer`, keeping credentials out of Sentry's event pipeline while still printing them locally.
- **Shared constant**: `SentryConfiguration.SeedUserCreatedLogPrefix` is used both as the log message prefix and as the filter anchor across all three Sentry hooks, preventing the log message and filters from drifting apart.
- **Defense-in-depth filters**: `BeforeSend` (drops events), `BeforeBreadcrumb` (drops breadcrumbs at all levels), and `BeforeSendLog` (drops forwarded Information logs) all use `ContainsSeedUserCredentials` to gate on the shared prefix.

<h3>Confidence Score: 5/5</h3>

The fix is safe to merge — it closes the credential-leak path through all three Sentry data channels and both prior review concerns are fully resolved.

The primary mitigation (Information-level logging) and all three defense-in-depth filters are correct. The shared constant prevents the log message and filter strings from drifting apart. Exception?.ToString() now also covers exception text. No data path is left unguarded.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/ResearchCruiseApp/Infrastructure/Sentry/SentryConfiguration.cs | Adds three Sentry filter hooks (BeforeSend, BeforeBreadcrumb, BeforeSendLog) plus a shared SeedUserCreatedLogPrefix constant and ContainsSeedUserCredentials helper; logic is correct and covers all known Sentry data paths. |
| backend/ResearchCruiseApp/Infrastructure/Persistence/Initialization/ApplicationDbContextInitializer.cs | Downgrades seed-credential log from Warning to Information and uses the shared SeedUserCreatedLogPrefix constant to keep the log message in sync with the Sentry filters. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Init as ApplicationDbContextInitializer
    participant Log as ILogger (Information)
    participant Sentry as Sentry SDK

    Init->>Log: "LogInformation("Seed User Created: {email} - {password}")"
    Note over Log,Sentry: MinimumEventLevel = Warning → no event created
    Log-->>Sentry: "breadcrumb (MinimumBreadcrumbLevel = Debug)"
    Sentry->>Sentry: BeforeBreadcrumb: ContainsSeedUserCredentials?
    Sentry-->>Sentry: return null → breadcrumb dropped ✓
    Log-->>Sentry: "SentryLogEntry (EnableLogs = true)"
    Sentry->>Sentry: BeforeSendLog: ContainsSeedUserCredentials?
    Sentry-->>Sentry: return null → log dropped ✓

    Note over Init,Sentry: Defense-in-depth: if level ever reverts to Warning
    Init->>Log: LogWarning (hypothetical regression)
    Log-->>Sentry: SentryEvent created
    Sentry->>Sentry: BeforeSend: ContainsSeedUserCredentials on Message + Exception?
    Sentry-->>Sentry: return null → event dropped ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Init as ApplicationDbContextInitializer
    participant Log as ILogger (Information)
    participant Sentry as Sentry SDK

    Init->>Log: "LogInformation("Seed User Created: {email} - {password}")"
    Note over Log,Sentry: MinimumEventLevel = Warning → no event created
    Log-->>Sentry: "breadcrumb (MinimumBreadcrumbLevel = Debug)"
    Sentry->>Sentry: BeforeBreadcrumb: ContainsSeedUserCredentials?
    Sentry-->>Sentry: return null → breadcrumb dropped ✓
    Log-->>Sentry: "SentryLogEntry (EnableLogs = true)"
    Sentry->>Sentry: BeforeSendLog: ContainsSeedUserCredentials?
    Sentry-->>Sentry: return null → log dropped ✓

    Note over Init,Sentry: Defense-in-depth: if level ever reverts to Warning
    Init->>Log: LogWarning (hypothetical regression)
    Log-->>Sentry: SentryEvent created
    Sentry->>Sentry: BeforeSend: ContainsSeedUserCredentials on Message + Exception?
    Sentry-->>Sentry: return null → event dropped ✓
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(sentry): share seed-credentials..."](https://github.com/vv01t3k/researchcruiseapp/commit/d8c9293da34259be428f9dc05338a234d569b916) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41921321)</sub>

<!-- /greptile_comment -->