### PR TITLE
Log seeded user credentials only after creation succeeds

### DIFF
--- a/backend/ResearchCruiseApp/Application/ExternalServices/IIdentityService.cs
+++ b/backend/ResearchCruiseApp/Application/ExternalServices/IIdentityService.cs
@@ -4,6 +4,12 @@ using ResearchCruiseApp.Application.Models.DTOs.Users;
 
 namespace ResearchCruiseApp.Application.ExternalServices;
 
+public enum SeedUserStatus
+{
+    AlreadyComplete,
+    Created,
+}
+
 public interface IIdentityService
 {
     Task<UserDto?> GetUserDtoById(Guid id);
@@ -40,6 +46,12 @@ public interface IIdentityService
     Task<Result> ResetPassword(ResetPasswordFormDto resetPasswordFormDto);
 
     Task<Result> AddUserWithRole(AddUserFormDto addUserFormDto, string password, string roleName);
+
+    Task<Result<SeedUserStatus>> EnsureSeedUserWithRole(
+        AddUserFormDto addUserFormDto,
+        string password,
+        string roleName
+    );
 
     Task<IList<string>> GetUserRolesNames(Guid userId);
 

--- a/backend/ResearchCruiseApp/Infrastructure/Persistence/Initialization/ApplicationDbContextInitializer.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Persistence/Initialization/ApplicationDbContextInitializer.cs
@@ -4,12 +4,14 @@ using ResearchCruiseApp.Application.Common.Extensions;
 using ResearchCruiseApp.Application.ExternalServices;
 using ResearchCruiseApp.Domain.Entities;
 using ResearchCruiseApp.Infrastructure.Persistence.Initialization.InitialData;
+using ResearchCruiseApp.Infrastructure.Services.Identity;
 
 namespace ResearchCruiseApp.Infrastructure.Persistence.Initialization;
 
 internal class ApplicationDbContextInitializer(
     ApplicationDbContext applicationDbContext,
     RoleManager<IdentityRole> roleManager,
+    UserManager<User> userManager,
     IIdentityService identityService,
     IRandomGenerator randomGenerator,
     IConfiguration configuration,
@@ -44,8 +46,23 @@ internal class ApplicationDbContextInitializer(
 
         foreach (var user in users)
         {
-            if (await identityService.UserWithEmailExists(user.Email))
-                continue;
+            var existingUser = await userManager.FindByEmailAsync(user.Email);
+            if (existingUser is not null)
+            {
+                if (await userManager.IsInRoleAsync(existingUser, user.Role!))
+                    continue;
+
+                var deleteResult = await userManager.DeleteAsync(existingUser);
+                if (!deleteResult.Succeeded)
+                {
+                    logger.LogWarning(
+                        "Incomplete seed user could not be removed: {Email} - {Error}",
+                        user.Email,
+                        string.Join(", ", deleteResult.Errors.Select(error => error.Description))
+                    );
+                    continue;
+                }
+            }
 
             var password = randomGenerator.CreateSecurePassword();
             var result = await identityService.AddUserWithRole(user, password, user.Role!);

--- a/backend/ResearchCruiseApp/Infrastructure/Persistence/Initialization/ApplicationDbContextInitializer.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Persistence/Initialization/ApplicationDbContextInitializer.cs
@@ -4,14 +4,12 @@ using ResearchCruiseApp.Application.Common.Extensions;
 using ResearchCruiseApp.Application.ExternalServices;
 using ResearchCruiseApp.Domain.Entities;
 using ResearchCruiseApp.Infrastructure.Persistence.Initialization.InitialData;
-using ResearchCruiseApp.Infrastructure.Services.Identity;
 
 namespace ResearchCruiseApp.Infrastructure.Persistence.Initialization;
 
 internal class ApplicationDbContextInitializer(
     ApplicationDbContext applicationDbContext,
     RoleManager<IdentityRole> roleManager,
-    UserManager<User> userManager,
     IIdentityService identityService,
     IRandomGenerator randomGenerator,
     IConfiguration configuration,
@@ -46,26 +44,8 @@ internal class ApplicationDbContextInitializer(
 
         foreach (var user in users)
         {
-            var existingUser = await userManager.FindByEmailAsync(user.Email);
-            if (existingUser is not null)
-            {
-                if (await userManager.IsInRoleAsync(existingUser, user.Role!))
-                    continue;
-
-                var deleteResult = await userManager.DeleteAsync(existingUser);
-                if (!deleteResult.Succeeded)
-                {
-                    logger.LogWarning(
-                        "Incomplete seed user could not be removed: {Email} - {Error}",
-                        user.Email,
-                        string.Join(", ", deleteResult.Errors.Select(error => error.Description))
-                    );
-                    continue;
-                }
-            }
-
             var password = randomGenerator.CreateSecurePassword();
-            var result = await identityService.AddUserWithRole(user, password, user.Role!);
+            var result = await identityService.EnsureSeedUserWithRole(user, password, user.Role!);
 
             if (!result.IsSuccess)
             {
@@ -78,8 +58,11 @@ internal class ApplicationDbContextInitializer(
             }
 
             if (
-                configuration.GetSection("Database:LogUserPasswordsWhenSeeding").Value?.ToBool()
-                ?? false
+                result.Data == SeedUserStatus.Created
+                && (
+                    configuration.GetSection("Database:LogUserPasswordsWhenSeeding").Value?.ToBool()
+                    ?? false
+                )
             )
             {
                 logger.LogWarning("Seed User Created: {Email} - {Password}", user.Email, password);

--- a/backend/ResearchCruiseApp/Infrastructure/Persistence/Initialization/ApplicationDbContextInitializer.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Persistence/Initialization/ApplicationDbContextInitializer.cs
@@ -12,7 +12,8 @@ internal class ApplicationDbContextInitializer(
     RoleManager<IdentityRole> roleManager,
     IIdentityService identityService,
     IRandomGenerator randomGenerator,
-    IConfiguration configuration
+    IConfiguration configuration,
+    ILogger<ApplicationDbContextInitializer> logger
 )
 {
     public async Task Initialize()
@@ -43,14 +44,28 @@ internal class ApplicationDbContextInitializer(
 
         foreach (var user in users)
         {
+            if (await identityService.UserWithEmailExists(user.Email))
+                continue;
+
             var password = randomGenerator.CreateSecurePassword();
-            await identityService.AddUserWithRole(user, password, user.Role!);
+            var result = await identityService.AddUserWithRole(user, password, user.Role!);
+
+            if (!result.IsSuccess)
+            {
+                logger.LogWarning(
+                    "Seed user was not created: {Email} - {Error}",
+                    user.Email,
+                    result.Error?.Message
+                );
+                continue;
+            }
+
             if (
                 configuration.GetSection("Database:LogUserPasswordsWhenSeeding").Value?.ToBool()
                 ?? false
             )
             {
-                Console.WriteLine($"Seed User Created: {user.Email} - {password}");
+                logger.LogWarning("Seed User Created: {Email} - {Password}", user.Email, password);
             }
         }
     }

--- a/backend/ResearchCruiseApp/Infrastructure/Services/Identity/IdentityService.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Services/Identity/IdentityService.cs
@@ -25,7 +25,8 @@ public class IdentityService(
     ICurrentUserService currentUserService,
     IMapper mapper,
     IConfiguration configuration,
-    IUnitOfWork unitOfWork
+    IUnitOfWork unitOfWork,
+    ILogger<IdentityService> logger
 ) : IIdentityService
 {
     public async Task<UserDto?> GetUserDtoById(Guid id)
@@ -276,7 +277,67 @@ public class IdentityService(
         return result.Succeeded ? Result.Empty : Error.UnknownIdentity();
     }
 
+    public async Task<Result<SeedUserStatus>> EnsureSeedUserWithRole(
+        AddUserFormDto addUserFormDto,
+        string password,
+        string roleName
+    )
+    {
+        var existingUser = await userManager.FindByEmailAsync(addUserFormDto.Email);
+        if (existingUser is not null)
+        {
+            if (await userManager.IsInRoleAsync(existingUser, roleName))
+                return SeedUserStatus.AlreadyComplete;
+
+            var deleteResult = await userManager.DeleteAsync(existingUser);
+            if (!deleteResult.Succeeded)
+                return deleteResult.ToApplicationResult().Error!;
+        }
+
+        var result = await CreateUserWithRole(addUserFormDto, password, roleName);
+        if (!result.IsSuccess)
+            return result.Error!;
+
+        try
+        {
+            await emailSender.SendAccountCreatedMessage(
+                await CreateUserDto(result.Data!),
+                roleName,
+                password
+            );
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(
+                exception,
+                "Seed user notification failed: {Email}",
+                addUserFormDto.Email
+            );
+        }
+
+        return SeedUserStatus.Created;
+    }
+
     public async Task<Result> AddUserWithRole(
+        AddUserFormDto addUserFormDto,
+        string password,
+        string roleName
+    )
+    {
+        var result = await CreateUserWithRole(addUserFormDto, password, roleName);
+        if (!result.IsSuccess)
+            return result.Error!;
+
+        await emailSender.SendAccountCreatedMessage(
+            await CreateUserDto(result.Data!),
+            roleName,
+            password
+        );
+
+        return Result.Empty;
+    }
+
+    private async Task<Result<User>> CreateUserWithRole(
         AddUserFormDto addUserFormDto,
         string password,
         string roleName
@@ -285,22 +346,16 @@ public class IdentityService(
         var user = CreateUser(addUserFormDto);
         var identityResult = await userManager.CreateAsync(user, password);
         if (!identityResult.Succeeded)
-            return identityResult.ToApplicationResult();
+            return identityResult.ToApplicationResult().Error!;
 
         identityResult = await userManager.AddToRoleAsync(user, roleName);
-        if (!identityResult.Succeeded)
-        {
-            var deleteResult = await userManager.DeleteAsync(user);
-            if (!deleteResult.Succeeded)
-                return deleteResult.ToApplicationResult();
+        if (identityResult.Succeeded)
+            return user;
 
-            return identityResult.ToApplicationResult();
-        }
-
-        var userDto = await CreateUserDto(user);
-        await emailSender.SendAccountCreatedMessage(userDto, roleName, password);
-
-        return Result.Empty;
+        var deleteResult = await userManager.DeleteAsync(user);
+        return (deleteResult.Succeeded ? identityResult : deleteResult)
+            .ToApplicationResult()
+            .Error!;
     }
 
     public async Task<IList<string>> GetUserRolesNames(Guid userId)

--- a/backend/ResearchCruiseApp/Infrastructure/Services/Identity/IdentityService.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Services/Identity/IdentityService.cs
@@ -290,7 +290,10 @@ public class IdentityService(
         identityResult = await userManager.AddToRoleAsync(user, roleName);
         if (!identityResult.Succeeded)
         {
-            await userManager.DeleteAsync(user);
+            var deleteResult = await userManager.DeleteAsync(user);
+            if (!deleteResult.Succeeded)
+                return deleteResult.ToApplicationResult();
+
             return identityResult.ToApplicationResult();
         }
 

--- a/backend/ResearchCruiseApp/Infrastructure/Services/Identity/IdentityService.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Services/Identity/IdentityService.cs
@@ -289,7 +289,10 @@ public class IdentityService(
 
         identityResult = await userManager.AddToRoleAsync(user, roleName);
         if (!identityResult.Succeeded)
+        {
+            await userManager.DeleteAsync(user);
             return identityResult.ToApplicationResult();
+        }
 
         var userDto = await CreateUserDto(user);
         await emailSender.SendAccountCreatedMessage(userDto, roleName, password);


### PR DESCRIPTION
## Summary

- Skip seed accounts only when they already have the configured role.
- Remove and recreate incomplete seed identities so a previous role-assignment failure is repaired with a known password.
- Retry incomplete-user cleanup on later startups if deletion itself fails.
- Log credentials only after user creation and role assignment both succeed; log failures without exposing the generated password.
- Rebase the focused fix onto the current `staging` branch.

## Review resolution

- Addresses the partial-seed review finding: a failed role assignment is compensated by deletion, and the next seed run detects/retries any incomplete identity rather than skipping it by email alone.

## Verification

- `dotnet csharpier check` on both changed files — passed.
- `dotnet build ResearchCruiseApp.sln` — passed (existing package-audit warnings remain on `staging`).
- `dotnet test ResearchCruiseApp.sln --no-build` — passed; this base branch has no separate test project.
- `git diff --check` — passed.

## Merge relationship with #362

This PR is individually mergeable into `staging`, but a local merge-tree simulation confirms an initializer conflict if #362 is merged afterward. The seed fix is already ported to #362. Recommended path when landing the v2 rewrite: close this PR as superseded by #362. If this PR must land first, refresh #362 and resolve the initializer conflict before merging it.

## Seed workflow ownership follow-up

- `IdentityService.EnsureSeedUserWithRole` now owns lookup, expected-role verification, incomplete-user cleanup, recreation, role-assignment rollback, and best-effort notification.
- The initializer no longer uses `UserManager` directly and logs credentials only for the explicit `Created` result; `AlreadyComplete` is a no-op.
- Notification failures are logged separately and do not invalidate an otherwise usable seeded account.
- Final standards/spec review found no violations, smells, missing requirements, or scope creep.
