### PR TITLE
build(backend): generate checked-in OpenAPI spec

### DIFF
--- a/backend/ResearchCruiseApp/Api/Applications/ApplicationCruise/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Applications/ApplicationCruise/Endpoints.cs
@@ -12,7 +12,7 @@ public static class ApplicationCruiseEndpoints
     {
         group
             .MapGet("/{applicationId:guid}/cruise", Get)
-            .WithName("GetApplicationCruiseV2")
+            .WithName("GetApplicationCruise")
             .WithSummary("Get the visible cruise linked to an application.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)

--- a/backend/ResearchCruiseApp/Api/Applications/ApplicationDecision/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Applications/ApplicationDecision/Endpoints.cs
@@ -13,7 +13,7 @@ public static class ApplicationDecisionEndpoints
     {
         group
             .MapPut("/{applicationId:guid}/decision", Update)
-            .WithName("UpdateApplicationDecisionV2")
+            .WithName("UpdateApplicationDecision")
             .WithSummary("Accept or reject an application.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)

--- a/backend/ResearchCruiseApp/Api/Applications/Catalog/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Applications/Catalog/Endpoints.cs
@@ -12,14 +12,14 @@ public static class CatalogEndpoints
     {
         group
             .MapGet("", GetAll)
-            .WithName("GetApplicationsV2")
+            .WithName("GetApplications")
             .WithSummary("Get visible applications.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AuthorizationPolicies.AnyKnownUser);
 
         group
             .MapGet("/{applicationId:guid}", Get)
-            .WithName("GetApplicationV2")
+            .WithName("GetApplication")
             .WithSummary("Get one visible application.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)

--- a/backend/ResearchCruiseApp/Api/Applications/CruisePlanning/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Applications/CruisePlanning/Endpoints.cs
@@ -13,7 +13,7 @@ public static class CruisePlanningEndpoints
     {
         group
             .MapGet("/for-cruise-planning", Get)
-            .WithName("GetApplicationsForCruisePlanningV2")
+            .WithName("GetApplicationsForCruisePlanning")
             .WithSummary("Get applications eligible for cruise planning.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AuthorizationPolicies.AnyKnownUser);

--- a/backend/ResearchCruiseApp/Api/Applications/Evaluation/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Applications/Evaluation/Endpoints.cs
@@ -12,7 +12,7 @@ public static class EvaluationEndpoints
     {
         group
             .MapGet("/{applicationId:guid}/evaluation", Get)
-            .WithName("GetApplicationEvaluationV2")
+            .WithName("GetApplicationEvaluation")
             .WithSummary("Get application evaluation details.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)

--- a/backend/ResearchCruiseApp/Api/Applications/FormA/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Applications/FormA/Endpoints.cs
@@ -15,7 +15,7 @@ public static class FormAEndpoints
     {
         group
             .MapPost("", Create)
-            .WithName("CreateApplicationV2")
+            .WithName("CreateApplication")
             .WithSummary("Create an application from Form A.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -24,7 +24,7 @@ public static class FormAEndpoints
 
         group
             .MapGet("/{applicationId:guid}/form-a", Get)
-            .WithName("GetApplicationFormAV2")
+            .WithName("GetApplicationFormA")
             .WithSummary("Get Form A.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -32,7 +32,7 @@ public static class FormAEndpoints
 
         group
             .MapPut("/{applicationId:guid}/form-a", Update)
-            .WithName("UpdateApplicationFormAV2")
+            .WithName("UpdateApplicationFormA")
             .WithSummary("Update Form A.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)

--- a/backend/ResearchCruiseApp/Api/Applications/FormB/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Applications/FormB/Endpoints.cs
@@ -15,7 +15,7 @@ public static class FormBEndpoints
     {
         group
             .MapGet("/{applicationId:guid}/form-b", Get)
-            .WithName("GetApplicationFormBV2")
+            .WithName("GetApplicationFormB")
             .WithSummary("Get Form B.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -23,7 +23,7 @@ public static class FormBEndpoints
 
         group
             .MapPut("/{applicationId:guid}/form-b", Update)
-            .WithName("UpdateApplicationFormBV2")
+            .WithName("UpdateApplicationFormB")
             .WithSummary("Create or replace Form B.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -34,7 +34,7 @@ public static class FormBEndpoints
 
         group
             .MapPut("/{applicationId:guid}/form-b/refill", Refill)
-            .WithName("RefillApplicationFormBV2")
+            .WithName("RefillApplicationFormB")
             .WithSummary("Return Form B to editable state.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden)

--- a/backend/ResearchCruiseApp/Api/Applications/FormC/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Applications/FormC/Endpoints.cs
@@ -14,7 +14,7 @@ public static class FormCEndpoints
     {
         group
             .MapGet("/{applicationId:guid}/form-c", Get)
-            .WithName("GetApplicationFormCV2")
+            .WithName("GetApplicationFormC")
             .WithSummary("Get Form C.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -22,7 +22,7 @@ public static class FormCEndpoints
 
         group
             .MapPut("/{applicationId:guid}/form-c", Update)
-            .WithName("UpdateApplicationFormCV2")
+            .WithName("UpdateApplicationFormC")
             .WithSummary("Create or replace Form C.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -33,7 +33,7 @@ public static class FormCEndpoints
 
         group
             .MapPut("/{applicationId:guid}/form-c/refill", Refill)
-            .WithName("RefillApplicationFormCV2")
+            .WithName("RefillApplicationFormC")
             .WithSummary("Return Form C to editable state.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)

--- a/backend/ResearchCruiseApp/Api/Applications/FormContext/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Applications/FormContext/Endpoints.cs
@@ -10,14 +10,14 @@ public static class FormContextEndpoints
     {
         group
             .MapGet("/form-a/context", GetFormAContext)
-            .WithName("GetApplicationFormAContextV2")
+            .WithName("GetApplicationFormAContext")
             .WithSummary("Get authenticated Form A context.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AuthorizationPolicies.AnyKnownUser);
 
         group
             .MapGet("/form-b/context", GetFormBContext)
-            .WithName("GetApplicationFormBContextV2")
+            .WithName("GetApplicationFormBContext")
             .WithSummary("Get authenticated Form B context.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AuthorizationPolicies.AnyKnownUser);

--- a/backend/ResearchCruiseApp/Api/Applications/SupervisorReview/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Applications/SupervisorReview/Endpoints.cs
@@ -12,14 +12,14 @@ public static class SupervisorReviewEndpoints
     {
         group
             .MapGet("/{applicationId:guid}/supervisor-review", Get)
-            .WithName("GetApplicationSupervisorReviewV2")
+            .WithName("GetApplicationSupervisorReview")
             .WithSummary("Get the anonymous supervisor review view.")
             .ProducesProblem(StatusCodes.Status404NotFound)
             .AllowAnonymous();
 
         group
             .MapPut("/{applicationId:guid}/supervisor-review/decision", UpdateDecision)
-            .WithName("UpdateApplicationSupervisorReviewDecisionV2")
+            .WithName("UpdateApplicationSupervisorReviewDecision")
             .WithSummary("Accept or reject an application as the anonymous supervisor.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status403Forbidden)

--- a/backend/ResearchCruiseApp/Api/Auth/EmailConfirmation/Contracts.cs
+++ b/backend/ResearchCruiseApp/Api/Auth/EmailConfirmation/Contracts.cs
@@ -1,5 +1,10 @@
+using Microsoft.AspNetCore.Mvc;
+
 namespace ResearchCruiseApp.Api.Auth;
 
-public sealed record ConfirmEmailRequest(Guid UserId, string Code);
+public sealed record ConfirmEmailRequest(
+    [property: FromQuery(Name = "userId")] Guid UserId,
+    [property: FromQuery(Name = "code")] string Code
+);
 
 public sealed record ResendConfirmationEmailRequest(string Email);

--- a/backend/ResearchCruiseApp/Api/Auth/EmailConfirmation/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Auth/EmailConfirmation/Endpoints.cs
@@ -15,7 +15,7 @@ public static class EmailConfirmationEndpoints
     {
         group
             .MapGet("/confirm-email", Confirm)
-            .WithName("ConfirmEmailV2")
+            .WithName("ConfirmEmail")
             .WithSummary("Confirm an account email.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -28,7 +28,7 @@ public static class EmailConfirmationEndpoints
     {
         group
             .MapPost("/resend-confirmation-email", Resend)
-            .WithName("ResendConfirmationEmailV2")
+            .WithName("ResendConfirmationEmail")
             .WithSummary("Resend an account confirmation email.")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status429TooManyRequests)

--- a/backend/ResearchCruiseApp/Api/Auth/Password/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Auth/Password/Endpoints.cs
@@ -16,7 +16,7 @@ public static class PasswordEndpoints
     {
         group
             .MapPost("/password-reset-request", RequestReset)
-            .WithName("RequestPasswordResetV2")
+            .WithName("RequestPasswordReset")
             .WithSummary("Request a password reset email.")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status429TooManyRequests)
@@ -29,7 +29,7 @@ public static class PasswordEndpoints
     {
         group
             .MapPost("/password-reset", Reset)
-            .WithName("ResetPasswordV2")
+            .WithName("ResetPassword")
             .WithSummary("Reset an account password.")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status401Unauthorized)

--- a/backend/ResearchCruiseApp/Api/Auth/Registration/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Auth/Registration/Endpoints.cs
@@ -10,7 +10,7 @@ public static class RegistrationEndpoints
     {
         group
             .MapPost("/register", Handle)
-            .WithName("RegisterAccountV2")
+            .WithName("RegisterAccount")
             .WithSummary("Register a new account.")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status429TooManyRequests)

--- a/backend/ResearchCruiseApp/Api/Auth/Sessions/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Auth/Sessions/Endpoints.cs
@@ -16,7 +16,7 @@ public static class SessionsEndpoints
     {
         group
             .MapPost("/login", Login)
-            .WithName("LoginV2")
+            .WithName("Login")
             .WithSummary("Sign in with an account.")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -30,7 +30,7 @@ public static class SessionsEndpoints
     {
         group
             .MapPost("/refresh", Refresh)
-            .WithName("RefreshTokensV2")
+            .WithName("RefreshTokens")
             .WithSummary("Refresh account tokens.")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status401Unauthorized)

--- a/backend/ResearchCruiseApp/Api/Cruises/Cruise/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Cruises/Cruise/Endpoints.cs
@@ -20,7 +20,7 @@ public static class CruiseEndpoints
     {
         group
             .MapPost("", Create)
-            .WithName("CreateCruiseV2")
+            .WithName("CreateCruise")
             .WithSummary("Create a cruise.")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status400BadRequest)
@@ -34,7 +34,7 @@ public static class CruiseEndpoints
     {
         group
             .MapPatch("/{cruiseId:guid}", Update)
-            .WithName("UpdateCruiseV2")
+            .WithName("UpdateCruise")
             .WithSummary("Update a cruise.")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status400BadRequest)
@@ -49,7 +49,7 @@ public static class CruiseEndpoints
     {
         group
             .MapDelete("/{cruiseId:guid}", Delete)
-            .WithName("DeleteCruiseV2")
+            .WithName("DeleteCruise")
             .WithSummary("Delete a cruise.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)

--- a/backend/ResearchCruiseApp/Api/Cruises/Export/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Cruises/Export/Endpoints.cs
@@ -14,7 +14,7 @@ public static class ExportEndpoints
     {
         group
             .MapGet("/export", Handle)
-            .WithName("ExportCruisesV2")
+            .WithName("ExportCruises")
             .WithSummary("Export visible cruises for a year.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)

--- a/backend/ResearchCruiseApp/Api/Cruises/Lifecycle/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Cruises/Lifecycle/Endpoints.cs
@@ -19,7 +19,7 @@ public static class LifecycleEndpoints
     {
         group
             .MapPut("/{cruiseId:guid}/confirmation", Confirm)
-            .WithName("ConfirmCruiseV2")
+            .WithName("ConfirmCruise")
             .WithSummary("Confirm a cruise.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden)
@@ -31,7 +31,7 @@ public static class LifecycleEndpoints
     {
         group
             .MapDelete("/{cruiseId:guid}/confirmation", RemoveConfirmation)
-            .WithName("RemoveCruiseConfirmationV2")
+            .WithName("RemoveCruiseConfirmation")
             .WithSummary("Revert the latest cruise lifecycle state.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -44,7 +44,7 @@ public static class LifecycleEndpoints
     {
         group
             .MapPut("/{cruiseId:guid}/completion", Complete)
-            .WithName("CompleteCruiseV2")
+            .WithName("CompleteCruise")
             .WithSummary("Mark a cruise as completed.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)

--- a/backend/ResearchCruiseApp/Api/Cruises/Lists/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Cruises/Lists/Endpoints.cs
@@ -19,7 +19,7 @@ public static class ListsEndpoints
     {
         group
             .MapGet("", GetAll)
-            .WithName("GetCruisesV2")
+            .WithName("GetCruises")
             .WithSummary("Get visible cruises.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AuthorizationPolicies.AnyKnownUser);
@@ -29,7 +29,7 @@ public static class ListsEndpoints
     {
         group
             .MapGet("/{cruiseId:guid}", GetById)
-            .WithName("GetCruiseV2")
+            .WithName("GetCruise")
             .WithSummary("Get one visible cruise.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)

--- a/backend/ResearchCruiseApp/Api/Cruises/Planning/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Cruises/Planning/Endpoints.cs
@@ -21,7 +21,7 @@ public static class PlanningEndpoints
     {
         group
             .MapPost("/auto-plan", AutoPlan)
-            .WithName("AutoPlanCruisesV2")
+            .WithName("AutoPlanCruises")
             .WithSummary("Automatically plan eligible cruises.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden)
@@ -32,7 +32,7 @@ public static class PlanningEndpoints
     {
         group
             .MapGet("/blockades", GetBlockades)
-            .WithName("GetCruiseBlockadesV2")
+            .WithName("GetCruiseBlockades")
             .WithSummary("Get blockade periods for a year.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AuthorizationPolicies.AnyKnownUser);

--- a/backend/ResearchCruiseApp/Api/Users/Acceptance/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Users/Acceptance/Endpoints.cs
@@ -16,7 +16,7 @@ public static class AcceptanceEndpoints
     {
         group
             .MapPut("/{userId:guid}/acceptance", Accept)
-            .WithName("AcceptUserV2")
+            .WithName("AcceptUser")
             .WithSummary("Accept a managed user.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden)
@@ -28,7 +28,7 @@ public static class AcceptanceEndpoints
     {
         group
             .MapDelete("/{userId:guid}/acceptance", Deactivate)
-            .WithName("DeactivateUserV2")
+            .WithName("DeactivateUser")
             .WithSummary("Deactivate a managed user.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden)

--- a/backend/ResearchCruiseApp/Api/Users/Accounts/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Users/Accounts/Endpoints.cs
@@ -17,7 +17,7 @@ public static class AccountsEndpoints
     {
         group
             .MapPost("", Create)
-            .WithName("CreateUserV2")
+            .WithName("CreateUser")
             .WithSummary("Create a user account.")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status400BadRequest)
@@ -32,7 +32,7 @@ public static class AccountsEndpoints
     {
         group
             .MapPatch("/{userId:guid}", Update)
-            .WithName("UpdateUserV2")
+            .WithName("UpdateUser")
             .WithSummary("Update a managed user.")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status400BadRequest)
@@ -47,7 +47,7 @@ public static class AccountsEndpoints
     {
         group
             .MapDelete("/{userId:guid}", Delete)
-            .WithName("DeleteUserV2")
+            .WithName("DeleteUser")
             .WithSummary("Delete a managed user.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden)

--- a/backend/ResearchCruiseApp/Api/Users/Lists/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Users/Lists/Endpoints.cs
@@ -15,7 +15,7 @@ public static class ListsEndpoints
     {
         group
             .MapGet("", GetAll)
-            .WithName("GetUsersV2")
+            .WithName("GetUsers")
             .WithSummary("Get manageable users.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden)
@@ -26,7 +26,7 @@ public static class ListsEndpoints
     {
         group
             .MapGet("/available-cruise-managers", GetAvailableCruiseManagers)
-            .WithName("GetAvailableCruiseManagersV2")
+            .WithName("GetAvailableCruiseManagers")
             .WithSummary("Get users available as cruise managers.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden)

--- a/backend/ResearchCruiseApp/Api/Users/Me/CruiseEffects/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Users/Me/CruiseEffects/Endpoints.cs
@@ -11,7 +11,7 @@ public static class CruiseEffectsEndpoints
     {
         group
             .MapGet("/cruise-effects", Handle)
-            .WithName("GetCurrentUserCruiseEffectsV2")
+            .WithName("GetCurrentUserCruiseEffects")
             .WithSummary("Get cruise effects for the current user.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)

--- a/backend/ResearchCruiseApp/Api/Users/Me/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Users/Me/Endpoints.cs
@@ -9,7 +9,7 @@ public static class MeEndpoints
     {
         group
             .MapGet("", Handle)
-            .WithName("GetCurrentUserV2")
+            .WithName("GetCurrentUser")
             .WithSummary("Get the current account.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .RequireAuthorization(AuthorizationPolicies.AnyKnownUser);

--- a/backend/ResearchCruiseApp/Api/Users/Me/Password/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Users/Me/Password/Endpoints.cs
@@ -10,7 +10,7 @@ public static class PasswordEndpoints
     {
         group
             .MapPatch("/password", Handle)
-            .WithName("ChangeCurrentUserPasswordV2")
+            .WithName("ChangeCurrentUserPassword")
             .WithSummary("Change the current account password.")
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status400BadRequest)

--- a/backend/ResearchCruiseApp/Api/Users/Me/Publications/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Users/Me/Publications/Endpoints.cs
@@ -21,7 +21,7 @@ public static class PublicationsEndpoints
     {
         group
             .MapGet("/publications", Get)
-            .WithName("GetCurrentUserPublicationsV2")
+            .WithName("GetCurrentUserPublications")
             .WithSummary("Get the current user's publications.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -32,7 +32,7 @@ public static class PublicationsEndpoints
     {
         group
             .MapPost("/publications/import", Import)
-            .WithName("ImportCurrentUserPublicationsV2")
+            .WithName("ImportCurrentUserPublications")
             .WithSummary("Import publications for the current user.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -45,7 +45,7 @@ public static class PublicationsEndpoints
     {
         group
             .MapDelete("/publications/{publicationId:guid}", Delete)
-            .WithName("DeleteCurrentUserPublicationV2")
+            .WithName("DeleteCurrentUserPublication")
             .WithSummary("Delete one publication from the current user.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -56,7 +56,7 @@ public static class PublicationsEndpoints
     {
         group
             .MapDelete("/publications", DeleteAll)
-            .WithName("DeleteAllCurrentUserPublicationsV2")
+            .WithName("DeleteAllCurrentUserPublications")
             .WithSummary("Delete all publications from the current user.")
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status404NotFound)

--- a/backend/ResearchCruiseApp/Api/Users/Roles/Endpoints.cs
+++ b/backend/ResearchCruiseApp/Api/Users/Roles/Endpoints.cs
@@ -16,7 +16,7 @@ public static class RolesEndpoints
     {
         group
             .MapPut("/{userId:guid}/roles/{roleName}", Add)
-            .WithName("AddUserRoleV2")
+            .WithName("AddUserRole")
             .WithSummary("Add a role to a managed user.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -29,7 +29,7 @@ public static class RolesEndpoints
     {
         group
             .MapDelete("/{userId:guid}/roles/{roleName}", Remove)
-            .WithName("RemoveUserRoleV2")
+            .WithName("RemoveUserRole")
             .WithSummary("Remove a role from a managed user.")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)

--- a/backend/ResearchCruiseApp/Program.cs
+++ b/backend/ResearchCruiseApp/Program.cs
@@ -38,13 +38,15 @@ builder.Services.AddOpenApi(
             );
     }
 );
-builder.Services.AddApiVersioning(options =>
-{
-    options.DefaultApiVersion = new ApiVersion(2, 0);
-    options.AssumeDefaultVersionWhenUnspecified = false;
-    options.ReportApiVersions = true;
-    options.ApiVersionReader = new UrlSegmentApiVersionReader();
-});
+builder
+    .Services.AddApiVersioning(options =>
+    {
+        options.DefaultApiVersion = new ApiVersion(2, 0);
+        options.AssumeDefaultVersionWhenUnspecified = false;
+        options.ReportApiVersions = true;
+        options.ApiVersionReader = new UrlSegmentApiVersionReader();
+    })
+    .AddApiExplorer(options => options.SubstituteApiVersionInUrl = true);
 builder.Services.AddAuthorization(AuthorizationPolicies.AddApiAuthorizationPolicies);
 builder.Services.AddRateLimiter(options =>
 {
@@ -134,7 +136,12 @@ app.MapGet(
     .ExcludeFromDescription();
 
 app.MapHealthChecks("/health");
-await app.InitializeDatabase();
+
+var isOpenApiGen = Assembly.GetEntryAssembly()?.GetName().Name == "GetDocument.Insider";
+if (!isOpenApiGen)
+{
+    await app.InitializeDatabase();
+}
 
 app.Run();
 

--- a/backend/ResearchCruiseApp/ResearchCruiseApp.csproj
+++ b/backend/ResearchCruiseApp/ResearchCruiseApp.csproj
@@ -20,8 +20,14 @@
     <SentryUploadSources>true</SentryUploadSources>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
+    <OpenApiDocumentsDirectory>openapi</OpenApiDocumentsDirectory>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Http" Version="10.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="MimeKit" Version="4.16.0" />
@@ -31,6 +37,11 @@
       Version="10.0.5"
     />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+    <PackageReference
+      Include="Microsoft.Extensions.ApiDescription.Server"
+      Version="10.0.5"
+      PrivateAssets="all"
+    />
     <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/backend/ResearchCruiseApp/openapi/ResearchCruiseApp_v2.json
+++ b/backend/ResearchCruiseApp/openapi/ResearchCruiseApp_v2.json
@@ -1,0 +1,5427 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "ResearchCruiseApp | v2",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v2/auth/login": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Sign in with an account.",
+        "operationId": "Login",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/auth/refresh": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Refresh account tokens.",
+        "operationId": "RefreshTokens",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshTokensRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/auth/register": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Register a new account.",
+        "operationId": "RegisterAccount",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterAccountRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/auth/confirm-email": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Confirm an account email.",
+        "operationId": "ConfirmEmail",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/auth/resend-confirmation-email": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Resend an account confirmation email.",
+        "operationId": "ResendConfirmationEmail",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResendConfirmationEmailRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/auth/password-reset-request": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Request a password reset email.",
+        "operationId": "RequestPasswordReset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RequestPasswordResetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/auth/password-reset": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Reset an account password.",
+        "operationId": "ResetPassword",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResetPasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users/me": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get the current account.",
+        "operationId": "GetCurrentUser",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentUserResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users/me/password": {
+      "patch": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Change the current account password.",
+        "operationId": "ChangeCurrentUserPassword",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users/me/cruise-effects": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get cruise effects for the current user.",
+        "operationId": "GetCurrentUserCruiseEffects",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CruiseEffectResponse"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users/me/publications": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get the current user's publications.",
+        "operationId": "GetCurrentUserPublications",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PublicationResponse"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Delete all publications from the current user.",
+        "operationId": "DeleteAllCurrentUserPublications",
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users/me/publications/import": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Import publications for the current user.",
+        "operationId": "ImportCurrentUserPublications",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ImportPublicationRequest"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users/me/publications/{publicationId}": {
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Delete one publication from the current user.",
+        "operationId": "DeleteCurrentUserPublication",
+        "parameters": [
+          {
+            "name": "publicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get manageable users.",
+        "operationId": "GetUsers",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Create a user account.",
+        "operationId": "CreateUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users/available-cruise-managers": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get users available as cruise managers.",
+        "operationId": "GetAvailableCruiseManagers",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CruiseManagerResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users/{userId}": {
+      "patch": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Update a managed user.",
+        "operationId": "UpdateUser",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Delete a managed user.",
+        "operationId": "DeleteUser",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users/{userId}/acceptance": {
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Accept a managed user.",
+        "operationId": "AcceptUser",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Deactivate a managed user.",
+        "operationId": "DeactivateUser",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/users/{userId}/roles/{roleName}": {
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Add a role to a managed user.",
+        "operationId": "AddUserRole",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "roleName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Remove a role from a managed user.",
+        "operationId": "RemoveUserRole",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "roleName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/cruises": {
+      "get": {
+        "tags": [
+          "Cruises"
+        ],
+        "summary": "Get visible cruises.",
+        "operationId": "GetCruises",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CruiseResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Cruises"
+        ],
+        "summary": "Create a cruise.",
+        "operationId": "CreateCruise",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/cruises/{cruiseId}": {
+      "get": {
+        "tags": [
+          "Cruises"
+        ],
+        "summary": "Get one visible cruise.",
+        "operationId": "GetCruise",
+        "parameters": [
+          {
+            "name": "cruiseId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CruiseResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Cruises"
+        ],
+        "summary": "Update a cruise.",
+        "operationId": "UpdateCruise",
+        "parameters": [
+          {
+            "name": "cruiseId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Cruises"
+        ],
+        "summary": "Delete a cruise.",
+        "operationId": "DeleteCruise",
+        "parameters": [
+          {
+            "name": "cruiseId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/cruises/{cruiseId}/confirmation": {
+      "put": {
+        "tags": [
+          "Cruises"
+        ],
+        "summary": "Confirm a cruise.",
+        "operationId": "ConfirmCruise",
+        "parameters": [
+          {
+            "name": "cruiseId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Cruises"
+        ],
+        "summary": "Revert the latest cruise lifecycle state.",
+        "operationId": "RemoveCruiseConfirmation",
+        "parameters": [
+          {
+            "name": "cruiseId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/cruises/{cruiseId}/completion": {
+      "put": {
+        "tags": [
+          "Cruises"
+        ],
+        "summary": "Mark a cruise as completed.",
+        "operationId": "CompleteCruise",
+        "parameters": [
+          {
+            "name": "cruiseId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/cruises/auto-plan": {
+      "post": {
+        "tags": [
+          "Cruises"
+        ],
+        "summary": "Automatically plan eligible cruises.",
+        "operationId": "AutoPlanCruises",
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/cruises/blockades": {
+      "get": {
+        "tags": [
+          "Cruises"
+        ],
+        "summary": "Get blockade periods for a year.",
+        "operationId": "GetCruiseBlockades",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BlockadeResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/cruises/export": {
+      "get": {
+        "tags": [
+          "Cruises"
+        ],
+        "summary": "Export visible cruises for a year.",
+        "operationId": "ExportCruises",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications": {
+      "get": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Get visible applications.",
+        "operationId": "GetApplications",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ApplicationResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Create an application from Form A.",
+        "operationId": "CreateApplication",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FormAWriteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/{applicationId}": {
+      "get": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Get one visible application.",
+        "operationId": "GetApplication",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/{applicationId}/cruise": {
+      "get": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Get the visible cruise linked to an application.",
+        "operationId": "GetApplicationCruise",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationCruiseResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/{applicationId}/evaluation": {
+      "get": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Get application evaluation details.",
+        "operationId": "GetApplicationEvaluation",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CruiseApplicationEvaluationDetailsDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/{applicationId}/decision": {
+      "put": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Accept or reject an application.",
+        "operationId": "UpdateApplicationDecision",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplicationDecisionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/for-cruise-planning": {
+      "get": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Get applications eligible for cruise planning.",
+        "operationId": "GetApplicationsForCruisePlanning",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CruiseApplicationDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/form-a/context": {
+      "get": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Get authenticated Form A context.",
+        "operationId": "GetApplicationFormAContext",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormAInitValuesDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/form-b/context": {
+      "get": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Get authenticated Form B context.",
+        "operationId": "GetApplicationFormBContext",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormBInitValuesDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/{applicationId}/form-a": {
+      "get": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Get Form A.",
+        "operationId": "GetApplicationFormA",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormADto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Update Form A.",
+        "operationId": "UpdateApplicationFormA",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FormAWriteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/{applicationId}/form-b": {
+      "get": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Get Form B.",
+        "operationId": "GetApplicationFormB",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormBDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Create or replace Form B.",
+        "operationId": "UpdateApplicationFormB",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FormBWriteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/{applicationId}/form-b/refill": {
+      "put": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Return Form B to editable state.",
+        "operationId": "RefillApplicationFormB",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/{applicationId}/form-c": {
+      "get": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Get Form C.",
+        "operationId": "GetApplicationFormC",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormCDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Create or replace Form C.",
+        "operationId": "UpdateApplicationFormC",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FormCWriteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/{applicationId}/form-c/refill": {
+      "put": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Return Form C to editable state.",
+        "operationId": "RefillApplicationFormC",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/{applicationId}/supervisor-review": {
+      "get": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Get the anonymous supervisor review view.",
+        "operationId": "GetApplicationSupervisorReview",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupervisorReviewResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/applications/{applicationId}/supervisor-review/decision": {
+      "put": {
+        "tags": [
+          "Applications"
+        ],
+        "summary": "Accept or reject an application as the anonymous supervisor.",
+        "operationId": "UpdateApplicationSupervisorReviewDecision",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SupervisorDecisionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApplicationCruiseApplicationSummaryResponse": {
+        "required": [
+          "id",
+          "cruiseManagerId",
+          "deputyManagerId",
+          "number",
+          "points"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cruiseManagerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deputyManagerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "number": {
+            "type": "string"
+          },
+          "points": {
+            "type": "string"
+          }
+        }
+      },
+      "ApplicationCruisePersonResponse": {
+        "required": [
+          "id",
+          "firstName",
+          "lastName"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          }
+        }
+      },
+      "ApplicationCruiseResponse": {
+        "required": [
+          "id",
+          "number",
+          "startDate",
+          "endDate",
+          "mainManager",
+          "deputyManager",
+          "applications",
+          "status",
+          "title",
+          "shipUnavailable"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "number": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "mainManager": {
+            "$ref": "#/components/schemas/ApplicationCruisePersonResponse"
+          },
+          "deputyManager": {
+            "$ref": "#/components/schemas/ApplicationCruisePersonResponse"
+          },
+          "applications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationCruiseApplicationSummaryResponse"
+            }
+          },
+          "status": {
+            "type": "string"
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "shipUnavailable": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ApplicationDecisionRequest": {
+        "required": [
+          "accept"
+        ],
+        "type": "object",
+        "properties": {
+          "accept": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ApplicationPersonResponse": {
+        "required": [
+          "id",
+          "email",
+          "firstName",
+          "lastName"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          }
+        }
+      },
+      "ApplicationResponse": {
+        "required": [
+          "id",
+          "number",
+          "date",
+          "year",
+          "mainManager",
+          "deputyManager",
+          "hasFormA",
+          "hasFormB",
+          "hasFormC",
+          "points",
+          "status",
+          "effectsDoneRate",
+          "note",
+          "cruiseHours",
+          "cruiseDays",
+          "acceptablePeriodBeg",
+          "acceptablePeriodEnd",
+          "optimalPeriodBeg",
+          "optimalPeriodEnd",
+          "precisePeriodStart",
+          "precisePeriodEnd",
+          "startDate",
+          "endDate"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "number": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date"
+          },
+          "year": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "mainManager": {
+            "$ref": "#/components/schemas/ApplicationPersonResponse"
+          },
+          "deputyManager": {
+            "$ref": "#/components/schemas/ApplicationPersonResponse"
+          },
+          "hasFormA": {
+            "type": "boolean"
+          },
+          "hasFormB": {
+            "type": "boolean"
+          },
+          "hasFormC": {
+            "type": "boolean"
+          },
+          "points": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "status": {
+            "type": "string"
+          },
+          "effectsDoneRate": {
+            "type": "string"
+          },
+          "note": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cruiseHours": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cruiseDays": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "float"
+          },
+          "acceptablePeriodBeg": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "acceptablePeriodEnd": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "optimalPeriodBeg": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "optimalPeriodEnd": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "precisePeriodStart": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "precisePeriodEnd": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "startDate": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          }
+        }
+      },
+      "ApplicationSummaryResponse": {
+        "required": [
+          "id",
+          "cruiseManagerId",
+          "deputyManagerId",
+          "number",
+          "points"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cruiseManagerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deputyManagerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "number": {
+            "type": "string"
+          },
+          "points": {
+            "type": "string"
+          }
+        }
+      },
+      "BlockadeResponse": {
+        "required": [
+          "startDate",
+          "endDate",
+          "title"
+        ],
+        "type": "object",
+        "properties": {
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "ChangePasswordRequest": {
+        "required": [
+          "password",
+          "newPassword"
+        ],
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": "string"
+          },
+          "newPassword": {
+            "type": "string"
+          }
+        }
+      },
+      "CollectedSampleDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "maxLength": 10240,
+            "minLength": 0,
+            "type": "string"
+          },
+          "amount": {
+            "maxLength": 10240,
+            "minLength": 0,
+            "type": "string"
+          },
+          "analysis": {
+            "maxLength": 10240,
+            "minLength": 0,
+            "type": "string"
+          },
+          "publishing": {
+            "maxLength": 10240,
+            "minLength": 0,
+            "type": "string"
+          }
+        }
+      },
+      "ContractDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "institutionName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "institutionUnit": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "institutionLocalization": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "scans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileDto"
+            }
+          }
+        }
+      },
+      "CreateRequest": {
+        "required": [
+          "startDate",
+          "endDate",
+          "mainManagerId",
+          "deputyManagerId",
+          "cruiseApplicationIds",
+          "title",
+          "shipUnavailable"
+        ],
+        "type": "object",
+        "properties": {
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "mainManagerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deputyManagerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cruiseApplicationIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "shipUnavailable": {
+            "type": "boolean"
+          }
+        }
+      },
+      "CreateUserRequest": {
+        "required": [
+          "email",
+          "firstName",
+          "lastName",
+          "roles"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "CrewMemberDto": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "firstName": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "lastName": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "birthPlace": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "birthDate": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "documentNumber": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "documentExpiryDate": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "institution": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          }
+        }
+      },
+      "CruiseApplicationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "number": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date"
+          },
+          "year": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "cruiseManagerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cruiseManagerEmail": {
+            "type": "string"
+          },
+          "cruiseManagerFirstName": {
+            "type": "string"
+          },
+          "cruiseManagerLastName": {
+            "type": "string"
+          },
+          "deputyManagerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deputyManagerEmail": {
+            "type": "string"
+          },
+          "deputyManagerFirstName": {
+            "type": "string"
+          },
+          "deputyManagerLastName": {
+            "type": "string"
+          },
+          "hasFormA": {
+            "type": "boolean"
+          },
+          "hasFormB": {
+            "type": "boolean"
+          },
+          "hasFormC": {
+            "type": "boolean"
+          },
+          "points": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "status": {
+            "type": "string"
+          },
+          "effectsDoneRate": {
+            "type": "string"
+          },
+          "note": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cruiseHours": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cruiseDays": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "float"
+          },
+          "acceptablePeriodBeg": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "acceptablePeriodEnd": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "optimalPeriodBeg": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "optimalPeriodEnd": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "precisePeriodStart": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "precisePeriodEnd": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "startDate": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          }
+        }
+      },
+      "CruiseApplicationEvaluationDetailsDto": {
+        "type": "object",
+        "properties": {
+          "formAResearchTasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormAResearchTaskDto"
+            }
+          },
+          "formAContracts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormAContractDto"
+            }
+          },
+          "ugTeams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UgTeamWithNameDto"
+            }
+          },
+          "guestTeams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuestTeamDto"
+            }
+          },
+          "ugUnitsPoints": {
+            "type": "string"
+          },
+          "formAPublications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormAPublicationDto"
+            }
+          },
+          "formASpubTasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormASpubTaskDto"
+            }
+          },
+          "effectsPoints": {
+            "type": "string"
+          }
+        }
+      },
+      "CruiseDayDetailsDto": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "hours": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "taskName": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "region": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "position": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "comment": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          }
+        }
+      },
+      "CruiseEffectResponse": {
+        "required": [
+          "id",
+          "userId",
+          "effect",
+          "points",
+          "cruiseApplicationId"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "effect": {
+            "$ref": "#/components/schemas/EffectResponse"
+          },
+          "points": {
+            "type": "string"
+          },
+          "cruiseApplicationId": {
+            "type": "string"
+          }
+        }
+      },
+      "CruiseManagerResponse": {
+        "required": [
+          "id",
+          "email",
+          "firstName",
+          "lastName"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          }
+        }
+      },
+      "CruiseResponse": {
+        "required": [
+          "id",
+          "number",
+          "startDate",
+          "endDate",
+          "mainManager",
+          "deputyManager",
+          "applications",
+          "status",
+          "title",
+          "shipUnavailable"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "number": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "mainManager": {
+            "$ref": "#/components/schemas/PersonResponse"
+          },
+          "deputyManager": {
+            "$ref": "#/components/schemas/PersonResponse"
+          },
+          "applications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationSummaryResponse"
+            }
+          },
+          "status": {
+            "type": "string"
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "shipUnavailable": {
+            "type": "boolean"
+          }
+        }
+      },
+      "CurrentUserResponse": {
+        "required": [
+          "id",
+          "email",
+          "firstName",
+          "lastName",
+          "roles",
+          "emailConfirmed",
+          "accepted"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "emailConfirmed": {
+            "type": "boolean"
+          },
+          "accepted": {
+            "type": "boolean"
+          }
+        }
+      },
+      "EffectResponse": {
+        "required": [
+          "type",
+          "title",
+          "magazine",
+          "author",
+          "institution",
+          "date",
+          "startDate",
+          "endDate",
+          "financingAmount",
+          "financingApproved",
+          "description",
+          "securedAmount",
+          "ministerialPoints",
+          "done",
+          "publicationMinisterialPoints",
+          "managerConditionMet",
+          "deputyConditionMet"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "magazine": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "author": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "institution": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "date": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "startDate": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "endDate": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "financingAmount": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "financingApproved": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "securedAmount": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ministerialPoints": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "done": {
+            "type": "string"
+          },
+          "publicationMinisterialPoints": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "managerConditionMet": {
+            "type": "string"
+          },
+          "deputyConditionMet": {
+            "type": "string"
+          }
+        }
+      },
+      "ExportResponse": {
+        "required": [
+          "name",
+          "content"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      },
+      "FileDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        }
+      },
+      "FormAContractDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "contract": {
+            "$ref": "#/components/schemas/ContractDto"
+          },
+          "points": {
+            "type": "string"
+          }
+        }
+      },
+      "FormADto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "cruiseManagerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deputyManagerId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "year": {
+            "maxLength": 4,
+            "minLength": 0,
+            "type": "string"
+          },
+          "acceptablePeriod": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "optimalPeriod": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "periodSelectionType": {
+            "maxLength": 16,
+            "minLength": 0,
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "precisePeriodStart": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "precisePeriodEnd": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "cruiseHours": {
+            "maxLength": 8,
+            "minLength": 0,
+            "type": "string"
+          },
+          "periodNotes": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "shipUsage": {
+            "maxLength": 1,
+            "minLength": 0,
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "differentUsage": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermissionDto"
+            }
+          },
+          "researchAreaDescriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchAreaDescriptionDto"
+            }
+          },
+          "cruiseGoal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cruiseGoalDescription": {
+            "maxLength": 10240,
+            "minLength": 0,
+            "type": "string"
+          },
+          "researchTasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchTaskDto"
+            }
+          },
+          "contracts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContractDto"
+            }
+          },
+          "ugTeams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UgTeamDto"
+            }
+          },
+          "guestTeams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuestTeamDto"
+            }
+          },
+          "publications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PublicationDto"
+            }
+          },
+          "spubTasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpubTaskDto"
+            }
+          },
+          "supervisorEmail": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "note": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "FormAInitValuesDto": {
+        "type": "object",
+        "properties": {
+          "cruiseManagers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormUserDto"
+            }
+          },
+          "deputyManagers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormUserDto"
+            }
+          },
+          "years": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "shipUsages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "standardSpubTasks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "researchAreas": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchAreaDto"
+            }
+          },
+          "cruiseGoals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "historicalResearchTasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchTaskDto"
+            }
+          },
+          "historicalContracts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContractDto"
+            }
+          },
+          "ugUnits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UgUnitDto"
+            }
+          },
+          "historicalGuestInstitutions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "historicalSpubTasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpubTaskDto"
+            }
+          },
+          "historicalPublications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PublicationDto"
+            }
+          }
+        }
+      },
+      "FormAPublicationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "publication": {
+            "$ref": "#/components/schemas/PublicationDto"
+          },
+          "points": {
+            "type": "string"
+          }
+        }
+      },
+      "FormAResearchTaskDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "researchTask": {
+            "$ref": "#/components/schemas/ResearchTaskDto"
+          },
+          "points": {
+            "type": "string"
+          }
+        }
+      },
+      "FormASpubTaskDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "spubTask": {
+            "$ref": "#/components/schemas/SpubTaskDto"
+          },
+          "points": {
+            "type": "string"
+          }
+        }
+      },
+      "FormAWriteRequest": {
+        "required": [
+          "form",
+          "draft"
+        ],
+        "type": "object",
+        "properties": {
+          "form": {
+            "$ref": "#/components/schemas/FormADto"
+          },
+          "draft": {
+            "type": "boolean"
+          }
+        }
+      },
+      "FormBDto": {
+        "type": "object",
+        "properties": {
+          "isCruiseManagerPresent": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermissionDto"
+            }
+          },
+          "ugTeams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UgTeamDto"
+            }
+          },
+          "guestTeams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuestTeamDto"
+            }
+          },
+          "crewMembers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CrewMemberDto"
+            }
+          },
+          "shortResearchEquipments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ShortResearchEquipmentDto"
+            }
+          },
+          "longResearchEquipments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LongResearchEquipmentDto"
+            }
+          },
+          "ports": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PortDto"
+            }
+          },
+          "cruiseDaysDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CruiseDayDetailsDto"
+            }
+          },
+          "researchEquipments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchEquipmentDto"
+            }
+          },
+          "shipEquipmentsIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "FormBInitValuesDto": {
+        "type": "object",
+        "properties": {
+          "shipEquipments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ShipEquipmentDto"
+            }
+          }
+        }
+      },
+      "FormBWriteRequest": {
+        "required": [
+          "form",
+          "draft"
+        ],
+        "type": "object",
+        "properties": {
+          "form": {
+            "$ref": "#/components/schemas/FormBDto"
+          },
+          "draft": {
+            "type": "boolean"
+          }
+        }
+      },
+      "FormCDto": {
+        "type": "object",
+        "properties": {
+          "shipUsage": {
+            "maxLength": 1,
+            "minLength": 0,
+            "type": "string"
+          },
+          "differentUsage": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermissionDto"
+            }
+          },
+          "researchAreaDescriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchAreaDescriptionDto"
+            }
+          },
+          "ugTeams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UgTeamDto"
+            }
+          },
+          "guestTeams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuestTeamDto"
+            }
+          },
+          "researchTasksEffects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchTaskEffectDto"
+            }
+          },
+          "contracts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContractDto"
+            }
+          },
+          "spubTasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpubTaskDto"
+            }
+          },
+          "shortResearchEquipments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ShortResearchEquipmentDto"
+            }
+          },
+          "longResearchEquipments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LongResearchEquipmentDto"
+            }
+          },
+          "ports": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PortDto"
+            }
+          },
+          "cruiseDaysDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CruiseDayDetailsDto"
+            }
+          },
+          "researchEquipments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchEquipmentDto"
+            }
+          },
+          "shipEquipmentsIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "collectedSamples": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CollectedSampleDto"
+            }
+          },
+          "spubReportData": {
+            "maxLength": 10240,
+            "minLength": 0,
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "additionalDescription": {
+            "maxLength": 10240,
+            "minLength": 0,
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "photos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileDto"
+            }
+          }
+        }
+      },
+      "FormCWriteRequest": {
+        "required": [
+          "form",
+          "draft"
+        ],
+        "type": "object",
+        "properties": {
+          "form": {
+            "$ref": "#/components/schemas/FormCDto"
+          },
+          "draft": {
+            "type": "boolean"
+          }
+        }
+      },
+      "FormUserDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          }
+        }
+      },
+      "GuestTeamDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "noOfPersons": {
+            "type": "string"
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "detail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "instance": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ImportPublicationRequest": {
+        "required": [
+          "category",
+          "doi",
+          "authors",
+          "title",
+          "magazine",
+          "year",
+          "ministerialPoints"
+        ],
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "doi": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "authors": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "magazine": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "year": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ministerialPoints": {
+            "type": "string"
+          }
+        }
+      },
+      "LoginRequest": {
+        "required": [
+          "email",
+          "password"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        }
+      },
+      "LongResearchEquipmentDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "action": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "duration": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          }
+        }
+      },
+      "PermissionDto": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "executive": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "scan": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/FileDto"
+              }
+            ]
+          }
+        }
+      },
+      "PersonResponse": {
+        "required": [
+          "id",
+          "firstName",
+          "lastName"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          }
+        }
+      },
+      "PortDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "startTime": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "endTime": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "detail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "instance": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "PublicationDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "category": {
+            "type": "string"
+          },
+          "doi": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "authors": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "magazine": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "year": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ministerialPoints": {
+            "type": "string"
+          }
+        }
+      },
+      "PublicationResponse": {
+        "required": [
+          "id",
+          "category",
+          "doi",
+          "authors",
+          "title",
+          "magazine",
+          "year",
+          "ministerialPoints"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "category": {
+            "type": "string"
+          },
+          "doi": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "authors": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "magazine": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "year": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ministerialPoints": {
+            "type": "string"
+          }
+        }
+      },
+      "RefreshTokensRequest": {
+        "required": [
+          "accessToken",
+          "refreshToken"
+        ],
+        "type": "object",
+        "properties": {
+          "accessToken": {
+            "type": "string"
+          },
+          "refreshToken": {
+            "type": "string"
+          }
+        }
+      },
+      "RegisterAccountRequest": {
+        "required": [
+          "email",
+          "password",
+          "firstName",
+          "lastName"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          }
+        }
+      },
+      "RequestPasswordResetRequest": {
+        "required": [
+          "email"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          }
+        }
+      },
+      "ResearchAreaDescriptionDto": {
+        "type": "object",
+        "properties": {
+          "areaId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "differentName": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "info": {
+            "maxLength": 10240,
+            "minLength": 0,
+            "type": "string"
+          }
+        }
+      },
+      "ResearchAreaDto": {
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ResearchEquipmentDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "insuranceStartDate": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "insuranceEndDate": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "permission": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          }
+        }
+      },
+      "ResearchTaskDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "magazine": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "author": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "institution": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "date": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "startDate": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "endDate": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "financingAmount": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "financingApproved": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "securedAmount": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ministerialPoints": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "ResearchTaskEffectDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "magazine": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "author": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "institution": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "date": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "startDate": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "endDate": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "financingAmount": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "financingApproved": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "securedAmount": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ministerialPoints": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "done": {
+            "type": "string"
+          },
+          "publicationMinisterialPoints": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "managerConditionMet": {
+            "type": "string"
+          },
+          "deputyConditionMet": {
+            "type": "string"
+          }
+        }
+      },
+      "ResendConfirmationEmailRequest": {
+        "required": [
+          "email"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          }
+        }
+      },
+      "ResetPasswordRequest": {
+        "required": [
+          "emailBase64",
+          "resetCode",
+          "password",
+          "passwordConfirm"
+        ],
+        "type": "object",
+        "properties": {
+          "emailBase64": {
+            "type": "string"
+          },
+          "resetCode": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "passwordConfirm": {
+            "type": "string"
+          }
+        }
+      },
+      "ShipEquipmentDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ShortResearchEquipmentDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "startDate": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "endDate": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          }
+        }
+      },
+      "SpubTaskDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "yearFrom": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "yearTo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "SupervisorDecisionRequest": {
+        "required": [
+          "accept",
+          "code"
+        ],
+        "type": "object",
+        "properties": {
+          "accept": {
+            "type": "boolean"
+          },
+          "code": {
+            "type": "string"
+          }
+        }
+      },
+      "SupervisorReviewResponse": {
+        "required": [
+          "form",
+          "initValues"
+        ],
+        "type": "object",
+        "properties": {
+          "form": {
+            "$ref": "#/components/schemas/FormADto"
+          },
+          "initValues": {
+            "$ref": "#/components/schemas/FormAInitValuesDto"
+          }
+        }
+      },
+      "TokenResponse": {
+        "required": [
+          "accessToken",
+          "accessTokenExpirationDate",
+          "refreshToken",
+          "refreshTokenExpirationDate"
+        ],
+        "type": "object",
+        "properties": {
+          "accessToken": {
+            "type": "string"
+          },
+          "accessTokenExpirationDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "refreshToken": {
+            "type": "string"
+          },
+          "refreshTokenExpirationDate": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "UgTeamDto": {
+        "type": "object",
+        "properties": {
+          "ugUnitId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "noOfEmployees": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "noOfStudents": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          }
+        }
+      },
+      "UgTeamWithNameDto": {
+        "type": "object",
+        "properties": {
+          "ugUnitName": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "noOfEmployees": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          },
+          "noOfStudents": {
+            "maxLength": 1024,
+            "minLength": 0,
+            "type": "string"
+          }
+        }
+      },
+      "UgUnitDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "UpdateRequest": {
+        "required": [
+          "startDate",
+          "endDate",
+          "mainManagerId",
+          "deputyManagerId",
+          "cruiseApplicationIds",
+          "title",
+          "shipUnavailable"
+        ],
+        "type": "object",
+        "properties": {
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "mainManagerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deputyManagerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cruiseApplicationIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "shipUnavailable": {
+            "type": "boolean"
+          }
+        }
+      },
+      "UpdateUserRequest": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "firstName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "lastName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "UserResponse": {
+        "required": [
+          "id",
+          "email",
+          "firstName",
+          "lastName",
+          "roles",
+          "emailConfirmed",
+          "accepted"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "emailConfirmed": {
+            "type": "boolean"
+          },
+          "accepted": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Auth"
+    },
+    {
+      "name": "Users"
+    },
+    {
+      "name": "Cruises"
+    },
+    {
+      "name": "Applications"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- remove the `V2` suffix from endpoint operation names
- generate the v2 OpenAPI document during Debug builds
- avoid database initialization while the document generator executes the application
- commit the generated OpenAPI document and verify its freshness in CI

This is the backend prerequisite for the stacked Orval frontend migration in #377.

## Verification

- backend build
- backend tests
- generated OpenAPI freshness diff

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds checked-in OpenAPI generation for the backend. The main changes are:

- Removes the `V2` suffix from endpoint operation names.
- Enables Debug-time generation of the v2 OpenAPI document.
- Skips database initialization while the document generator runs the app.
- Adds API Explorer support for substituted versioned routes.
- Checks in the generated `ResearchCruiseApp_v2.json` file.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/ResearchCruiseApp/Program.cs | Adds versioned API Explorer setup and skips database initialization during OpenAPI document generation. |
| backend/ResearchCruiseApp/ResearchCruiseApp.csproj | Enables Debug OpenAPI generation and adds the package references needed for document generation. |
| backend/ResearchCruiseApp/Api/Auth/EmailConfirmation/Contracts.cs | Adds explicit query binding metadata for the confirm-email request. |
| backend/ResearchCruiseApp/openapi/ResearchCruiseApp_v2.json | Adds the generated v2 OpenAPI document. |

</details>

<sub>Reviews (2): Last reviewed commit: ["build(backend): generate checked-in Open..."](https://github.com/vv01t3k/researchcruiseapp/commit/824e0776909f96e7dfb8c4ae36cbbdabb83cf5ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44196724)</sub>

<!-- /greptile_comment -->