### PR TITLE
feat(backend): add fake SMTP for local development

### DIFF
--- a/backend/ResearchCruiseApp.Tests/SeedUserWorkflowTests.cs
+++ b/backend/ResearchCruiseApp.Tests/SeedUserWorkflowTests.cs
@@ -35,7 +35,8 @@ public sealed class SeedUserWorkflowTests
         var emailSender = new EmailSender(
             configuration,
             new TemplateFileReader(),
-            new GlobalizationService()
+            new GlobalizationService(),
+            NullLogger<EmailSender>.Instance
         );
         const string email = "seed@example.com";
         const string role = "Administrator";

--- a/backend/ResearchCruiseApp/Infrastructure/Email/EmailSender.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Email/EmailSender.cs
@@ -136,7 +136,9 @@ internal class EmailSender(
 
         if (smtpSettings.GetValue<bool>("UseFakeSmtp"))
         {
-            var directory = Path.Combine(Path.GetTempPath(), "ResearchCruiseApp-emails");
+            var directory = Path.GetFullPath(
+                Path.Combine(Directory.GetCurrentDirectory(), "..", "fake-emails")
+            );
             Directory.CreateDirectory(directory);
 
             var path = Path.Combine(

--- a/backend/ResearchCruiseApp/Infrastructure/Email/EmailSender.cs
+++ b/backend/ResearchCruiseApp/Infrastructure/Email/EmailSender.cs
@@ -14,7 +14,8 @@ namespace ResearchCruiseApp.Infrastructure.Email;
 internal class EmailSender(
     IConfiguration configuration,
     TemplateFileReader templateFileReader,
-    GlobalizationService globalizationService
+    GlobalizationService globalizationService,
+    ILogger<EmailSender> logger
 )
 {
     public async Task SendEmailConfirmationEmail(
@@ -132,6 +133,23 @@ internal class EmailSender(
     private async Task SendEmail(string email, string subject, string body)
     {
         var smtpSettings = configuration.GetSection("SmtpSettings");
+
+        if (smtpSettings.GetValue<bool>("UseFakeSmtp"))
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "ResearchCruiseApp-emails");
+            Directory.CreateDirectory(directory);
+
+            var path = Path.Combine(
+                directory,
+                $"{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid():N}.html"
+            );
+            await File.WriteAllTextAsync(path, $"<!-- To: {email}\nSubject: {subject} -->\n{body}");
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                logger.LogInformation("Fake SMTP: email to {Email} saved to {Path}", email, path);
+            }
+            return;
+        }
 
         using var client = new SmtpClient();
         await client.ConnectAsync(

--- a/backend/ResearchCruiseApp/appsettings.Development.json
+++ b/backend/ResearchCruiseApp/appsettings.Development.json
@@ -23,5 +23,8 @@
   },
   "Sentry": {
     "Environment": "local"
+  },
+  "SmtpSettings": {
+    "UseFakeSmtp": true
   }
 }


### PR DESCRIPTION
## Summary
- Adds a development-only fake SMTP path that writes outbound emails to temp HTML files instead of sending them.
- Logs the saved email path at information level when enabled.
- Updates the seed user workflow test to pass the new `EmailSender` logger dependency.
- Enables fake SMTP by default in `appsettings.Development.json`.

## Testing
- Not run.
- Verified the diff updates the `EmailSender` constructor call in tests to match the new dependency list.
- Verified development settings set `SmtpSettings:UseFakeSmtp` to `true`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds local email capture for development. The main changes are:

- Writes outbound emails to temporary HTML files when fake SMTP is enabled.
- Logs the path of each captured email.
- Enables fake SMTP in Development configuration.
- Adds the logger dependency to `EmailSender` and its test construction.

<h3>Confidence Score: 4/5</h3>

The temporary email storage needs access controls before merging.

- Captured messages contain plaintext passwords and bearer tokens.
- The predictable temporary directory can be readable or pre-created by another local process.
- Captured files have no cleanup policy and can exhaust temporary storage.
- The logger dependency is compatible with the existing DI setup and updated test caller.

backend/ResearchCruiseApp/Infrastructure/Email/EmailSender.cs

<details open><summary><h3>Security Review</h3></summary>

The fake SMTP path stores passwords and bearer tokens in a predictable shared temporary directory without owner-only permissions or ownership validation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/ResearchCruiseApp/Infrastructure/Email/EmailSender.cs | Adds fake SMTP capture and logging, but the temporary storage lacks access controls and retention. |
| backend/ResearchCruiseApp/appsettings.Development.json | Enables fake SMTP for the Development environment. |
| backend/ResearchCruiseApp.Tests/SeedUserWorkflowTests.cs | Updates the direct `EmailSender` construction with a null logger. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
backend/ResearchCruiseApp/Infrastructure/Email/EmailSender.cs:139-140
**Shared Temp Directory Exposes Tokens**

The predictable directory is created under the system temp path without owner-only permissions or ownership checks. On a shared development host, another local process can pre-create or read this directory and obtain captured plaintext passwords, reset links, confirmation tokens, and supervisor approval codes.

### Issue 2 of 2
backend/ResearchCruiseApp/Infrastructure/Email/EmailSender.cs:146
**Email Captures Grow Without Bound**

Every fake email creates a persistent file with no retention limit or cleanup. Repeated registration, reset, or resend requests can fill a small container or `/tmp` filesystem; `WriteAllTextAsync` then throws, causing affected user workflows to fail instead of capturing the email.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add fake SMTP output for development"](https://github.com/vv01t3k/researchcruiseapp/commit/f538d37ca071954041265e4408ae0a80eddb5eb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44647006)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->