### PR TITLE
hotfix: rotate SMTP app password

### DIFF
--- a/backend/ResearchCruiseApp/appsettings.json
+++ b/backend/ResearchCruiseApp/appsettings.json
@@ -12,7 +12,7 @@
     "SmtpServer": "smtp.gmail.com",
     "SmtpPort": 465,
     "SmtpUsername": "bauniwersytetu@gmail.com",
-    "SmtpPassword": "yamw skcf jfzj aiqn",
+    "SmtpPassword": "vaep nnic enbj tnaq",
     "SenderName": "Biuro Armatora z jednostką r/v Oceanograf, Uniwersytet Gdański"
   },
   "FrontendUrl": "http://localhost:8080",


### PR DESCRIPTION
temporary fix

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rotates the SMTP credential used by the backend. The change is:

- Replaces the Gmail app password in `appsettings.json`.

<h3>Confidence Score: 2/5</h3>

The exposed SMTP credential makes this unsafe to merge.

- The checked-in value is used for SMTP authentication when no environment override exists.
- The production Docker configuration does not provide an override.
- Repository and container-image readers can recover and misuse the credential.

backend/ResearchCruiseApp/appsettings.json

<details open><summary><h3>Security Review</h3></summary>

The new SMTP app password is stored in tracked configuration and remains available through Git history. Revoke it and supply its replacement through the existing environment or deployment-secret mechanism.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/ResearchCruiseApp/appsettings.json | Replaces a plaintext SMTP password in tracked runtime configuration. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/ResearchCruiseApp/appsettings.json:15
**Live SMTP Credential Exposed**

This tracked setting contains the replacement Gmail app password used by `AuthenticateAsync` when production does not override `SmtpSettings__SmtpPassword`; the Docker production configuration has no such override. Anyone with repository or image access can recover the credential and send mail as this account, and deleting it in a later commit will not remove it from Git history.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["hotfix: rotate SMTP app password"](https://github.com/vv01t3k/researchcruiseapp/commit/cb88bca0abe5f16796ef8a0081a3da5e6059bd4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46358459)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->