### PR TITLE
hotfix: rotate SMTP app password

### DIFF
--- a/backend/ResearchCruiseApp/appsettings.json
+++ b/backend/ResearchCruiseApp/appsettings.json
@@ -12,7 +12,7 @@
     "SmtpServer": "smtp.gmail.com",
     "SmtpPort": 465,
     "SmtpUsername": "bauniwersytetu@gmail.com",
-    "SmtpPassword": "yamw skcf jfzj aiqn",
+    "SmtpPassword": "vaep nnic enbj tnaq",
     "SenderName": "Biuro Armatora z jednostką r/v Oceanograf, Uniwersytet Gdański"
   },
   "FrontendUrl": "http://localhost:8080",


### PR DESCRIPTION
temporary fix

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rotates the SMTP app password in the backend configuration. The change is:

- Replaces the Gmail SMTP password stored in `appsettings.json`.

<h3>Confidence Score: 2/5</h3>

The exposed SMTP credential makes this unsafe to merge.

- The rotated password is stored in Git.
- Default Docker deployments consume this setting during SMTP authentication.
- Repository readers can use the credential to send mail as the configured account.

backend/ResearchCruiseApp/appsettings.json

<details open><summary><h3>Security Review</h3></summary>

The rotated Gmail app password is committed in plaintext and used by the default SMTP runtime path. It must be revoked and replaced with a credential supplied through deployment secrets or environment variables.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| backend/ResearchCruiseApp/appsettings.json | Replaces one plaintext SMTP app password with another in tracked runtime configuration. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
backend/ResearchCruiseApp/appsettings.json:15
**Rotated SMTP Credential Remains Exposed**

This line commits the replacement Gmail app password to Git, exposing it to every repository reader and retained clone. Docker Compose does not override `SmtpSettings__SmtpPassword`, so the backend passes this value to SMTP authentication; anyone who obtains it can impersonate the sender or consume its mail quota. Revoke it and inject a new credential through the existing secret or environment-variable path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["hotfix: rotate SMTP app password"](https://github.com/vv01t3k/researchcruiseapp/commit/c03d9e93901f26ebd6e1221dc51be49b770bc831) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46361849)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->